### PR TITLE
samples: point to the correct kata-deploy image

### DIFF
--- a/config/samples/_v1beta1_confidentialcontainersruntime.yaml
+++ b/config/samples/_v1beta1_confidentialcontainersruntime.yaml
@@ -8,4 +8,4 @@ spec:
   runtimeName: kata
   config:
     installType: bundle
-    payloadImage: quay.io/kata-containers/kata-deploy:latest
+    payloadImage: quay.io/kata-containers/kata-deploy-cc:v0


### PR DESCRIPTION
Instead of pointing to the latest released kata-deploy image, which does
not contain any work related to the confidential containers effort, let's
point to the `kata-deploy-cc:v0` one instead.

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>