### PR TITLE
Add "CONFIGURE_CC=yes" env variable for kata-deploy image

### DIFF
--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -19,6 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -28,8 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -437,6 +438,10 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 											FieldPath: "spec.nodeName",
 										},
 									},
+								},
+								{
+									Name:  "CONFIGURE_CC",
+									Value: "yes",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
kata-deploy image uses the CONFIGURE_CC env variable to specifically add the CC config . 