### PR TITLE
Do not assume amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
+# Golang image and version (defaults are provided).
+# Use e.g. `golang` for multi-arch support.
+ARG IMG_NAME
+ARG IMG_VERSION
+
 # Build the manager binary
-FROM quay.io/bitnami/golang:1.16 as builder
+FROM ${IMG_NAME:-quay.io/bitnami/golang}:${IMG_VERSION:-1.16} as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +20,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
- Use docker.io/library/golang as container base image --
  quay.io/bitnami/golang does not support e.g. s390x
- Do not specify GOARCH -- uses native anyway

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

@bpradipt if you're very keen on keeping quay.io (e.g. because of rate limiting), we might be able to figure out something else