### PR TITLE
Switch to dockerhub image for bitnami

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG IMG_NAME
 ARG IMG_VERSION
 
 # Build the manager binary
-FROM ${IMG_NAME:-quay.io/bitnami/golang}:${IMG_VERSION:-1.16} as builder
+FROM ${IMG_NAME:-docker.io/bitnami/golang}:${IMG_VERSION:-1.16} as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
The bitnami images will only be available from dockerhub and gcr going
forward
Fixes: #34