### PR TITLE
Update ccv0 demo instructions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,58 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:  
+  push:
+    tags:
+      - '*'
+
+env:
+
+  REGISTRY: quay.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_ID }}
+          password: ${{ secrets.QUAY_SECRET }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,32 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Download controller-gen
+      run: make controller-gen
+
+    - name: Download kustomize
+      run: make kustomize
+
+    - name: Download envtest
+      run: make envtest
+
+    - name: Build controller
+      run: make build

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Instructions to recreate the demo setup in your own environment is available [he
 
 ## Installation
 
-Please refer to the following [instructions](.docs/INSTALL.md)
+Please refer to the following [instructions](docs/INSTALL.md)
 
 ## Development
 
-Please refer to the following [instructions](.docs/DEVELOPMENT.md)
+Please refer to the following [instructions](docs/DEVELOPMENT.md)

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ An operator to deploy confidential containers runtime (and required configs) on 
 
 Ensure KUBECONFIG points to target Kubernetes cluster
 ```
-kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/master/deploy/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
 ```
 
 ## Create Custom Resource (CR)
 ```
-kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/operator/master/config/samples/ccruntime.yaml
+kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
 ```
 
 ## Changing Runtime bundle
@@ -37,10 +37,10 @@ spec:
 
 Delete the CR
 ```
-kubectl delete  -f https://raw.githubusercontent.com/confidential-containers/operator/master/config/samples/ccruntime.yaml
+kubectl delete  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
 ```
 
 Delete the Operator
 ```
-kubectl delete -f https://raw.githubusercontent.com/confidential-containers/operator/master/deploy/deploy.yaml
+kubectl delete -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# Introduction
-An operator to deploy confidential containers runtime (and required configs) on a Kubernetes cluster
+# Confidential Containers Operator
+
+[![Build](https://github.com/confidential-containers/operator/actions/workflows/makefile.yml/badge.svg)](https://github.com/confidential-containers/operator/actions/workflows/makefile.yml)
+[![Container Image](https://github.com/confidential-containers/operator/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/confidential-containers/operator/actions/workflows/docker-publish.yml)
+
+This Confidential Containers Operator provides a means to deploy and manage Confidential Containers Runtime on Kubernetes clusters. 
+The primary resource is `CcRuntime` which describes runtime details like installation type, source, nodes to deploy etc.
 
 ## Installation
 
-Ensure KUBECONFIG points to target Kubernetes cluster
+Ensure KUBECONFIG points to the target Kubernetes cluster
 ```
 kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
 ```
@@ -15,7 +20,7 @@ kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/oper
 
 ## Changing Runtime bundle
 
-The operator by default uses the `quay.io/kata-containers/kata-deploy-cc:v0` image
+The operator by default uses the `quay.io/confidential-contianers/runtime-payload:v0` image
 as the payload.
 You can change it when creating the CR by changing the `payloadImage` config.
 The following yaml shows an example where `v2` version of the image is used
@@ -30,7 +35,7 @@ spec:
   runtimeName: kata
   config:
     installType: bundle
-    payloadImage: quay.io/kata-containers/kata-deploy-cc:v2
+    payloadImage: quay.io/confidential-contianers/runtime-payload:v2
 ```
 
 ## Uninstallation

--- a/README.md
+++ b/README.md
@@ -6,46 +6,16 @@
 This Confidential Containers Operator provides a means to deploy and manage Confidential Containers Runtime on Kubernetes clusters. 
 The primary resource is `CcRuntime` which describes runtime details like installation type, source, nodes to deploy etc.
 
+Here is a short demo video showing the operator in action.
+
+[![asciicast](https://asciinema.org/a/450899.svg)](https://asciinema.org/a/450899)
+
+Instructions to recreate the demo setup in your own environment is available [here](https://github.com/confidential-containers/operator/blob/ccv0-demo/demo/README.md) 
+
 ## Installation
 
-Ensure KUBECONFIG points to the target Kubernetes cluster
-```
-kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
-```
+Please refer to the following [instructions](.docs/INSTALL.md)
 
-## Create Custom Resource (CR)
-```
-kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
-```
+## Development
 
-## Changing Runtime bundle
-
-The operator by default uses the `quay.io/confidential-contianers/runtime-payload:v0` image
-as the payload.
-You can change it when creating the CR by changing the `payloadImage` config.
-The following yaml shows an example where `v2` version of the image is used
-```
-apiVersion: confidentialcontainers.org/v1beta1
-kind: CcRuntime
-metadata:
-  name: ccruntime-sample
-  namespace: confidential-containers-system
-spec:
-  # Add fields here
-  runtimeName: kata
-  config:
-    installType: bundle
-    payloadImage: quay.io/confidential-contianers/runtime-payload:v2
-```
-
-## Uninstallation
-
-Delete the CR
-```
-kubectl delete  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
-```
-
-Delete the Operator
-```
-kubectl delete -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
-```
+Please refer to the following [instructions](.docs/DEVELOPMENT.md)

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -297,7 +297,7 @@ func (r *CcRuntimeReconciler) monitorCcRuntimeInstallation() (ctrl.Result, error
 }
 
 func (r *CcRuntimeReconciler) setRuntimeClass() (ctrl.Result, error) {
-	runtimeClassNames := []string{"kata-qemu", "kata"}
+	runtimeClassNames := []string{"kata-qemu", "kata", "kata-cc"}
 
 	for _, runtimeClassName := range runtimeClassNames {
 		rc := func() *nodeapi.RuntimeClass {

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -92,6 +92,8 @@ func (r *CcRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 func (r *CcRuntimeReconciler) processCcRuntimeDeleteRequest() (ctrl.Result, error) {
+	// Delete kata-deploy daemonset
+	// Run kata-cleanup logic
 	return ctrl.Result{}, nil
 }
 
@@ -230,7 +232,7 @@ func (r *CcRuntimeReconciler) monitorCcRuntimeInstallation() (ctrl.Result, error
 }
 
 func (r *CcRuntimeReconciler) setRuntimeClass() (ctrl.Result, error) {
-	runtimeClassNames := []string{"kata-qemu-virtiofs", "kata-qemu", "kata-clh", "kata-fc", "kata"}
+	runtimeClassNames := []string{"kata-qemu", "kata"}
 
 	for _, runtimeClassName := range runtimeClassNames {
 		rc := func() *nodeapi.RuntimeClass {

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -19,6 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -28,8 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
-	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -437,6 +438,10 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 											FieldPath: "spec.nodeName",
 										},
 									},
+								},
+								{
+									Name:  "CONFIGURE_CC",
+									Value: "yes",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -13,7 +13,7 @@ const (
 	// UpgradeOperation denotes the upgrade operation
 	UpgradeOperation DaemonOperation = "upgrade"
 
-	RuntimeConfigFinalizer = "finalizer.runtimeconfig.confidentialcontainers.org"
+	RuntimeConfigFinalizer = "runtimeconfig.confidentialcontainers.org/finalizer"
 )
 
 func contains(list []string, s string) bool {

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -496,7 +496,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: quay.io/confidential-containers/operator:latest
+        image: quay.io/confidential-containers/operator:demo
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,42 +2,137 @@
 
 Ensure KUBECONFIG points to the target Kubernetes cluster
 ```
-kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/ccv0-demo/deploy/deploy.yaml
 ```
 
 ## Create Custom Resource (CR)
 ```
-kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
+kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/operator/ccv0-demo/config/samples/ccruntime.yaml
 ```
 
-## Changing Runtime bundle
-
-The operator by default uses the `quay.io/confidential-contianers/runtime-payload:v0` image
-as the payload.
-You can change it when creating the CR by changing the `payloadImage` config.
-The following yaml shows an example where `v2` version of the image is used
+## Verify the RuntimeClasses
 ```
-apiVersion: confidentialcontainers.org/v1beta1
-kind: CcRuntime
+kubectl get runtimeclass
+```
+
+You should see a similar output like below:
+
+```
+NAME        HANDLER     AGE
+kata        kata        13s
+kata-cc     kata-cc     13s
+kata-qemu   kata-qemu   13s
+```
+
+## Create a sample POD
+
+```
+cat >nginx-cc.yaml <<EOF
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: ccruntime-sample
-  namespace: confidential-containers-system
+  name: nginx-deployment-cc
 spec:
-  # Add fields here
-  runtimeName: kata
-  config:
-    installType: bundle
-    payloadImage: quay.io/confidential-contianers/runtime-payload:v2
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      runtimeClassName: kata-cc
+      containers:
+      - name: nginx
+        image: bitnami/nginx:1.14
+        ports:
+        - containerPort: 80
+        imagePullPolicy: Always  
+EOF
+
+kubectl apply -f nginx-cc.yaml
 ```
+
+### Verify 
+
+Check if the POD is in "Running" state.
+
+```
+kubectl get deploy
+
+NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+nginx-deployment-cc   1/1     1            1           24s
+
+
+kubectl get pods -o wide
+
+NAME                                   READY   STATUS    RESTARTS   AGE   IP            NODE               NOMINATED NODE   READINESS GATES
+nginx-deployment-cc-5c4d54569f-4wlqg   1/1     Running   0          1m    10.244.1.18   testk8s-worker-0   <none>           <none>
+```
+
+`Exec` is blocked and will error out.
+
+```
+kubectl exec -it nginx-deployment-cc-5c4d54569f-4wlqg -- bash
+
+error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "8f8abe4a06a9bd3a2f70803336064dfbcbb8f7595412eed6efb2d6ee665f737f": cannot enter container 830f6da3ed785ed7f082c11482610e307f9b6aa5f18fe6c1be36c165b578f31e, with err rpc error: code = Unimplemented desc = ExecProcessRequest is blocked: unknown
+```
+
+Verify the `rootfs` of the container is not present on the worker node.
+
+Get container ID from the POD.
+
+```
+export PODNAME=nginx-deployment-cc-5c4d54569f-4wlqg
+containerID=$(kubectl get pod $PODNAME -o=jsonpath='{.status.containerStatuses[*].containerID}' | cut -d "/" -f3)
+
+echo $containerID
+
+830f6da3ed785ed7f082c11482610e307f9b6aa5f18fe6c1be36c165b578f31e
+```
+
+Login to the worker node (`testk8s-worker-0`) and run the following commands to extract the sandbox ID.
+
+```
+export containerID=830f6da3ed785ed7f082c11482610e307f9b6aa5f18fe6c1be36c165b578f31e
+
+sandboxID=$(sudo crictl -r unix:///run/containerd/containerd.sock inspect $containerID | grep 'sandboxID' | cut -d ":" -f2 | sed 's/,//g;s/"//g;s/ //g')
+
+echo $sandboxID
+```
+
+Check container `rootfs`.
+```
+sudo -E sandboxID=$sandboxID su
+cd /run/kata-containers/shared/sandboxes/$sandboxID/shared
+find . -name rootfs
+
+./c560ddca8bca8e8f98f9879bc93bb6ec8d5a65b98cb43c1da3dca77e65e7d3da/rootfs
+
+ls -l ./c560ddca8bca8e8f98f9879bc93bb6ec8d5a65b98cb43c1da3dca77e65e7d3da/rootfs
+total 684
+drwxr-xr-x 2 root root   4096 May 11 05:21 dev
+drwxr-xr-x 2 root root   4096 May 11 05:21 etc
+-rwxr-xr-x 1 root root 682696 Aug 25  2021 pause
+drwxr-xr-x 2 root root   4096 May 11 05:21 proc
+drwxr-xr-x 2 root root   4096 May 11 05:21 sys
+
+```
+
+As you can see, only the `rootfs` for the `pause` container is present on the host. The `rootfs for the application container `nginx`
+is inside the VM.
+ 
+For regular Kata containers, using either `kata` or `kata-qemu` runtimeclass, you'll find the `rootfs` for all the containers.
 
 ## Uninstallation
 
 Delete the CR
 ```
-kubectl delete  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
+kubectl delete  -f https://raw.githubusercontent.com/confidential-containers/operator/ccv0-demo/config/samples/ccruntime.yaml
 ```
 
 Delete the Operator
 ```
-kubectl delete -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
+kubectl delete -f https://raw.githubusercontent.com/confidential-containers/operator/ccv0-demo/deploy/deploy.yaml
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,43 @@
+## Installation
+
+Ensure KUBECONFIG points to the target Kubernetes cluster
+```
+kubectl apply -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
+```
+
+## Create Custom Resource (CR)
+```
+kubectl apply  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
+```
+
+## Changing Runtime bundle
+
+The operator by default uses the `quay.io/confidential-contianers/runtime-payload:v0` image
+as the payload.
+You can change it when creating the CR by changing the `payloadImage` config.
+The following yaml shows an example where `v2` version of the image is used
+```
+apiVersion: confidentialcontainers.org/v1beta1
+kind: CcRuntime
+metadata:
+  name: ccruntime-sample
+  namespace: confidential-containers-system
+spec:
+  # Add fields here
+  runtimeName: kata
+  config:
+    installType: bundle
+    payloadImage: quay.io/confidential-contianers/runtime-payload:v2
+```
+
+## Uninstallation
+
+Delete the CR
+```
+kubectl delete  -f https://raw.githubusercontent.com/confidential-containers/operator/main/config/samples/ccruntime.yaml
+```
+
+Delete the Operator
+```
+kubectl delete -f https://raw.githubusercontent.com/confidential-containers/operator/main/deploy/deploy.yaml
+```


### PR DESCRIPTION
The series is to ensure a workable setup when using`ccv0-demo` branch.
It merges key commits from `main` to `ccv0-demo` as well as points to correct images 
- Operator: quay.io/confidential-containers/operator:demo
- Payload: quay.io/confidential-containers/runtime-payload:v0

Tested the instructions successfully on a 2 node K8s cluster running on Ubuntu 20.04
```
kubectl get nodes -o wide

NAME               STATUS   ROLES                  AGE   VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION     CONTAINER-RUNTIME
testk8s-master-0   Ready    control-plane,master   18h   v1.24.0   192.168.121.37   <none>        Ubuntu 20.04.3 LTS   5.4.0-91-generic   containerd://1.6.4
testk8s-worker-0   Ready    worker                 18h   v1.24.0   192.168.121.17   <none>        Ubuntu 20.04.3 LTS   5.4.0-91-generic   containerd://1.6.0-beta.0-512-gc8f5e4509
```

```
kubectl get pods -n confidential-containers-system

NAME                                              READY   STATUS    RESTARTS   AGE
cc-operator-controller-manager-5f45c6878d-8qbdq   2/2     Running   0          49m
cc-operator-daemon-install-gq5wv                  1/1     Running   0          49m
[kcli@virtlab714 operator]$ kubectl get pods -n confidential-containers-system -o wide
NAME                                              READY   STATUS    RESTARTS   AGE   IP            NODE               NOMINATED NODE   READINESS GATES
cc-operator-controller-manager-5f45c6878d-8qbdq   2/2     Running   0          49m   10.244.1.16   testk8s-worker-0   <none>           <none>
cc-operator-daemon-install-gq5wv                  1/1     Running   0          49m   10.244.1.17   testk8s-worker-0   <none>           <none>
```

```
kubectl get runtimeclass

NAME        HANDLER     AGE
kata        kata        49m
kata-cc     kata-cc     49m
kata-qemu   kata-qemu   49m
```

```
kubectl get pods
NAME                                   READY   STATUS    RESTARTS   AGE
nginx-deployment-cc-5c4d54569f-4wlqg   1/1     Running   0          47m

kubectl get pods -o yaml | grep -i runtimeclass
runtimeClassName: kata-cc

kubectl exec -it nginx-deployment-cc-5c4d54569f-4wlqg -- bash
error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "b0f8453fd791bbaa5de1f3decfa50c3a45475be1cedcc68ca560debdacee9099": cannot enter container 830f6da3ed785ed7f082c11482610e307f9b6aa5f18fe6c1be36c165b578f31e, with err rpc error: code = Unimplemented desc = ExecProcessRequest is blocked: unknown
```
