### PR TITLE
allow re-installation by deleting labels and preinstall daemonset

### DIFF
--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -745,12 +745,17 @@ func (r *CcRuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 func (r *CcRuntimeReconciler) deleteUninstallDaemonsets() (ctrl.Result, error) {
-	ds := r.processDaemonset(InstallOperation)
+	ds := r.processDaemonset(UninstallOperation)
 	result, err := r.deleteDaemonset(ds)
 	if err != nil {
 		return result, err
 	}
 	ds = r.makeHookDaemonset(PostUninstallOperation)
+	result, err = r.deleteDaemonset(ds)
+	if err != nil {
+		return result, err
+	}
+	ds = r.makeHookDaemonset(PreInstallOperation)
 	result, err = r.deleteDaemonset(ds)
 	if err != nil {
 		return result, err

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -228,6 +228,32 @@ func (r *CcRuntimeReconciler) processCcRuntimeDeleteRequest() (ctrl.Result, erro
 						return result, err
 					}
 					result, err = r.deleteUninstallDaemonsets()
+					prepostLabels := map[string]string{}
+					if r.ccRuntime.Spec.Config.PreInstall.Image != "" {
+						prepostLabels[PreInstallDoneLabel[0]] = PreInstallDoneLabel[1]
+					}
+					if r.ccRuntime.Spec.Config.PostUninstall.Image != "" {
+						prepostLabels[PostUninstallDoneLabel[0]] = PostUninstallDoneLabel[1]
+
+					}
+					err, nodes := r.getNodesWithLabels(prepostLabels)
+					if err != nil {
+						r.Log.Error(err, "an error occured when getting the list of nodes from which we want to"+
+							"remove preinstall/postuninstall labels")
+						return ctrl.Result{}, err
+					}
+					postuninstalledNodes := len(nodes.Items)
+					if !allNodesDone(postuninstalledNodes, r) {
+						return ctrl.Result{Requeue: true}, nil
+					} else {
+						if postuninstalledNodes > 0 {
+							result, err = r.removeNodeLabels(nodes)
+							if err != nil {
+								r.Log.Error(err, "removing the labels from nodes failed")
+								return ctrl.Result{}, err
+							}
+						}
+					}
 				}
 			}
 			return result, err
@@ -846,4 +872,38 @@ func (r *CcRuntimeReconciler) makeHookDaemonset(operation DaemonOperation) *apps
 			},
 		},
 	}
+}
+
+func (r *CcRuntimeReconciler) removeNodeLabels(nodesList *corev1.NodeList) (ctrl.Result, error) {
+	nodesClient, err := r.getNodeClient()
+	if err != nil {
+		r.Log.Info("Couldn't get nodes client")
+		return ctrl.Result{}, err
+	}
+
+	for _, node := range nodesList.Items {
+		nodeLabels := node.GetLabels()
+		if val, ok := nodeLabels[PreInstallDoneLabel[0]]; ok && val == PreInstallDoneLabel[1] {
+			delete(nodeLabels, PreInstallDoneLabel[0])
+		}
+
+		if val, ok := nodeLabels[PostUninstallDoneLabel[0]]; ok && val == PostUninstallDoneLabel[1] {
+			delete(nodeLabels, PostUninstallDoneLabel[0])
+		}
+
+		if val, ok := nodeLabels[KataRuntimeLabel[0]]; ok && val == KataRuntimeLabel[1] {
+			delete(nodeLabels, KataRuntimeLabel[0])
+		}
+		node.SetLabels(nodeLabels)
+		_, err := nodesClient.Update(context.TODO(), &node, metav1.UpdateOptions{
+			TypeMeta:     metav1.TypeMeta{},
+			DryRun:       nil,
+			FieldManager: "",
+		})
+		if err != nil {
+			r.Log.Info("failed to update node labels")
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -3,6 +3,12 @@ package controllers
 // DaemonOperation represents the operation the daemon is going to perform
 type DaemonOperation string
 
+var (
+	PreInstallDoneLabel    = []string{"cc-preinstall/done", "true"}
+	PostUninstallDoneLabel = []string{"cc-postuninstall/done", "true"}
+	KataRuntimeLabel       = []string{"katacontainers.io/kata-runtime", "cleanup"}
+)
+
 const (
 	// InstallOperation denotes the installation operation
 	InstallOperation DaemonOperation = "install"


### PR DESCRIPTION
This contains two patches. The first one adds code to delete pre-install and post-uninstall
done labels. The second one deletes the pre-install daemon set so that it will be started
again when a new CR is created. 

Fixes: #50 #54