### PR TITLE
Update ccruntime after finalizer removed

### DIFF
--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -257,6 +257,10 @@ func (r *CcRuntimeReconciler) processCcRuntimeDeleteRequest() (ctrl.Result, erro
 					}
 				}
 			}
+			if err != nil {
+				return result, err
+			}
+			result, err = r.updateCcRuntime()
 			return result, err
 		}
 


### PR DESCRIPTION
We need to update the CCRuntime CR after we have removed
the finalizer. When no postuninstall DaemonSet was used we
return values that mean we don't update the CR instance.

Fix this by updating the status before returning.


Fixes: #58 
Reported-by: Snir Sheriber <ssheribe@redhat.com>