### PR TITLE
ci: bootstrap the test env and install the operator

### DIFF
--- a/tests/e2e/Vagrantfile
+++ b/tests/e2e/Vagrantfile
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is a Vagrant configuration file.
+#
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Read the Kata Containers CI job from the CI_JOB environment variable.
+job = ENV['CI_JOB'] || ""
+guest_home_dir = '/home/vagrant'
+host_arch = `uname -m`.strip
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+
+  # By default vagrant sync the current directory. Let's disabled it because the directory
+  # will be synced later to the proper destination.
+  config.vm.synced_folder ".", "/vagrant", disabled:true
+  config.vm.synced_folder "../../", "#{guest_home_dir}/src/confidential-containers/operator", type:"rsync"
+
+  config.vm.provider "libvirt" do |lv|
+    lv.driver = "kvm"
+    lv.cpus = "4"
+    lv.memory = "8192"
+    # Domains on Libvirt will be created with the following prefix.
+    lv.default_prefix = "cc-operator_test-"
+    if host_arch == "x86_64"
+      lv.machine_type = "q35"
+    end
+  end
+
+  config.vm.define "tests-e2e-ubuntu2004", autostart: false do |ubuntu|
+    ubuntu.vm.box = "generic/ubuntu2004"
+
+    ubuntu.vm.provision "shell", inline: <<-SHELL
+      sudo apt-get -y update
+      sudo apt-get -y install ansible
+      cd "#{guest_home_dir}/src/confidential-containers/operator/tests/e2e"
+      ansible-playbook -i localhost, -c local ansible/main.yml
+      sudo ./cluster/up.sh
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      sudo -E ./operator.sh || true
+    SHELL
+  end
+
+end

--- a/tests/e2e/Vagrantfile
+++ b/tests/e2e/Vagrantfile
@@ -42,11 +42,7 @@ Vagrant.configure("2") do |config|
       sudo apt-get -y update
       sudo apt-get -y install ansible
       cd "#{guest_home_dir}/src/confidential-containers/operator/tests/e2e"
-      ansible-playbook -i localhost, -c local ansible/main.yml
-      sudo ./cluster/up.sh
-      export KUBECONFIG=/etc/kubernetes/admin.conf
-      sudo -E ./operator.sh || true
+      ./run-local.sh
     SHELL
   end
-
 end

--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -1,0 +1,7 @@
+---
+# Please keep alphabetically sorted.
+#
+container_runtime: containerd
+go_version: 1.18.5
+operator_sdk_version: v1.23.0
+k8s_version: v1.24.0

--- a/tests/e2e/ansible/install_build_deps.yml
+++ b/tests/e2e/ansible/install_build_deps.yml
@@ -37,3 +37,20 @@
         mode: '+x'
     # TODO: import only if ubuntu host.
     - import_tasks: install_docker_ubuntu.yml
+    #
+    # Undo the installation.
+    #
+    - name: Uninstall build dependencies
+      tags: undo
+      block:
+        - name: Uninstall operator-sdk
+          file:
+            path: /usr/local/bin/operator-sdk
+            state: absent
+        - name: Uninstall go
+          file:
+            path: "{{ item }}"
+            state: absent
+          with_items:
+            - /usr/local/bin/go
+            - /usr/local/go

--- a/tests/e2e/ansible/install_build_deps.yml
+++ b/tests/e2e/ansible/install_build_deps.yml
@@ -1,0 +1,39 @@
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install the build dependencies.
+#
+---
+- hosts: all
+  become: yes
+  tasks:
+    - name: Install build packages
+      package:
+        name:
+          - make
+          - gcc
+        state: present
+    - block:
+      - name: Download and extract Go tarball
+        unarchive:
+          # TODO: use facts
+          src: https://go.dev/dl/go{{ go_version }}.linux-amd64.tar.gz
+          creates: /usr/local/go
+          dest: /usr/local
+          remote_src: yes
+        register: go_install
+      - name: Create link to go binary
+        file:
+          src: /usr/local/go/bin/go
+          dest: /usr/local/bin/go
+          state: link
+        when: go_install.changed == True
+    - name: Install the operator-sdk
+      get_url:
+        # TODO: use facts
+        url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk_linux_amd64
+        dest: /usr/local/bin/operator-sdk
+        mode: '+x'
+    # TODO: import only if ubuntu host.
+    - import_tasks: install_docker_ubuntu.yml

--- a/tests/e2e/ansible/install_containerd.yml
+++ b/tests/e2e/ansible/install_containerd.yml
@@ -1,0 +1,34 @@
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install the containerd runtime. The operator will replace the container
+# runtime, so this is required only to bootstrap the cluster.
+#
+---
+- hosts: all
+  become: yes
+  tasks:
+    - name: Install containerd.io from distro
+      package:
+        name: "containerd.io"
+        state: present
+    # The docker package overwrite the /etc/containerd/config.toml installed
+    # by the containerd.io package. As a result we are hit by the following
+    # problems:
+    #
+    #   - `kubeadm init` fails on preflight checks if containerd has 'cri'
+    #   plug-in disabled. See https://github.com/containerd/containerd/issues/4581
+    #   - Kubelet fails to scan the containerd endpoint after ccruntime is
+    #   deployed then the node gets marked 'UnReady'. See
+    #   https://github.com/containerd/containerd/issues/4581
+    #
+    # Those issues are solved by re-generating the containerd configuration
+    # file with its defaults.
+    - name: Re-create containerd config
+      shell: containerd config default > /etc/containerd/config.toml
+    - name: Restart containerd service
+      service:
+        name: containerd
+        enabled: yes
+        state: restarted

--- a/tests/e2e/ansible/install_containerd.yml
+++ b/tests/e2e/ansible/install_containerd.yml
@@ -32,3 +32,16 @@
         name: containerd
         enabled: yes
         state: restarted
+    #
+    # Undo the installation.
+    #
+    - name: Revert containerd config to defaults
+      tags: undo
+      block:
+        - name: Re-create containerd config
+          shell: containerd config default > /etc/containerd/config.toml
+        - name: Restart containerd service
+          service:
+            name: containerd
+            enabled: yes
+            state: restarted

--- a/tests/e2e/ansible/install_docker_ubuntu.yml
+++ b/tests/e2e/ansible/install_docker_ubuntu.yml
@@ -1,0 +1,37 @@
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install docker on the host as it is used to build the operator.
+#
+---
+- name: Install docker dependencies
+  package:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+- name: Add docker repo GPG key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    keyring: /etc/apt/trusted.gpg.d/docker.gpg
+    state: present
+- name: Add docker repo
+  apt_repository:
+    repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable"
+    filename: docker
+    update_cache: yes
+    state: present
+- name: Install docker packages
+  package:
+    name:
+      - docker-ce
+      - docker-ce-cli
+    state: present
+- name: Create the docker group
+  group:
+    name: docker
+    state: present
+# TODO: add regular non-root users to docker group

--- a/tests/e2e/ansible/install_kubeadm.yml
+++ b/tests/e2e/ansible/install_kubeadm.yml
@@ -1,0 +1,108 @@
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install kubeadm and everything else needed to bring up a single node
+# k8s cluster.
+#
+---
+- hosts: all
+  become: yes
+  vars:
+    cni_home: "/opt/cni"
+    cni_version: "v1.1.1"
+    flannel_version: "v0.19.1"
+    kubeadm_cri_runtime_socket: "/run/containerd/containerd.sock"
+    kubeadm_conf_dir: "/etc/kubeadm"
+    kubelet_bin: "/usr/local/bin/kubelet"
+    # Use 'cgroupfs' with containerd, 'systemd' with crio?
+    kubelet_cgroup_driver: "cgroupfs"
+  tasks:
+    - name: Install kubeadm required packages
+      package:
+        name:
+          # conntrack and socat are needed by the `kubeadm init` preflight checks
+          - conntrack
+          - socat
+        state: present
+    - name: Create CNI home directory
+      file:
+        path: "{{ cni_home }}/bin"
+        state: directory
+    - name: Install CNI plugins
+      unarchive:
+        # TODO: use facts
+        src: "https://github.com/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-linux-amd64-{{ cni_version }}.tgz"
+        dest: "{{ cni_home }}/bin"
+        remote_src: yes
+    - name: Install crictl
+      unarchive:
+        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ k8s_version }}/crictl-{{ k8s_version }}-linux-amd64.tar.gz"
+        creates: /usr/local/bin/crictl
+        dest: /usr/local/bin
+        remote_src: yes
+    - name: Install kube binaries
+      get_url:
+        url: https://storage.googleapis.com/kubernetes-release/release/{{ k8s_version }}/bin/linux/amd64/{{ item }}
+        dest: /usr/local/bin
+        mode: '+x'
+      with_items:
+        - kubeadm
+        - kubelet
+        - kubectl
+    - name: Disable swap
+      shell: |
+        [ -z "$(swapon --show)" ] && exit 0
+        swapoff --all && exit 1
+        exit 2
+      register: result
+      changed_when: result.rc == 1
+      failed_when: result.rc > 1
+    - name: Disable swap in fstab
+      replace:
+        path: /etc/fstab
+        regexp: '^([^#\s]+\s+){2}swap\s'
+        replace: '# \1'
+    - name: Create kubelet service
+      template:
+        src: kubelet.service.j2
+        dest: /etc/systemd/system/kubelet.service
+      vars:
+        kubelet_bin: /usr/local/bin/kubelet
+    - name: Create kubelet.service.d directory
+      file:
+        path: /etc/systemd/system/kubelet.service.d
+        state: directory
+    - name: Create kubeadm service config
+      template:
+        src: 10-kubeadm.conf.j2
+        dest: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+      vars:
+        kubelet_bin: /usr/local/bin/kubelet
+    - name: Create kubeadm configuration directory
+      file:
+        path: "{{ kubeadm_conf_dir }}"
+        state: directory
+    - name: Create kubeadm configuration file
+      template:
+        src: kubeadm.conf.j2
+        dest: "{{ kubeadm_conf_dir }}/kubeadm.conf"
+    - name: Start kubelet service
+      service:
+        name: kubelet
+        enabled: yes
+        state: started
+    - name: Create flannel home directory
+      file:
+        path: /opt/flannel
+        state: directory
+#    - name: Install flanneld
+#      unarchive:
+#        src: https://github.com/flannel-io/flannel/releases/download/{{ flannel_version }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz
+#        creates: /opt/bin/flanneld
+#        dest: /opt/bin
+#        remote_src: yes
+    - name: Create flannel deployment file
+      template:
+        src: kube-flannel.yml.j2
+        dest: /opt/flannel/kube-flannel.yml

--- a/tests/e2e/ansible/install_kubeadm.yml
+++ b/tests/e2e/ansible/install_kubeadm.yml
@@ -11,10 +11,13 @@
   vars:
     cni_home: "/opt/cni"
     cni_version: "v1.1.1"
+    flannel_home: "/opt/flannel"
     flannel_version: "v0.19.1"
     kubeadm_cri_runtime_socket: "/run/containerd/containerd.sock"
     kubeadm_conf_dir: "/etc/kubeadm"
     kubelet_bin: "/usr/local/bin/kubelet"
+    kubelet_service_dir: "/etc/systemd/system/kubelet.service.d"
+    kubelet_service_file: "/etc/systemd/system/kubelet.service"
     # Use 'cgroupfs' with containerd, 'systemd' with crio?
     kubelet_cgroup_driver: "cgroupfs"
   tasks:
@@ -66,17 +69,17 @@
     - name: Create kubelet service
       template:
         src: kubelet.service.j2
-        dest: /etc/systemd/system/kubelet.service
+        dest: "{{ kubelet_service_file }}"
       vars:
         kubelet_bin: /usr/local/bin/kubelet
     - name: Create kubelet.service.d directory
       file:
-        path: /etc/systemd/system/kubelet.service.d
+        path: "{{ kubelet_service_dir }}"
         state: directory
     - name: Create kubeadm service config
       template:
         src: 10-kubeadm.conf.j2
-        dest: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+        dest: "{{ kubelet_service_dir }}/10-kubeadm.conf"
       vars:
         kubelet_bin: /usr/local/bin/kubelet
     - name: Create kubeadm configuration directory
@@ -94,15 +97,49 @@
         state: started
     - name: Create flannel home directory
       file:
-        path: /opt/flannel
+        path: "{{ flannel_home }}"
         state: directory
-#    - name: Install flanneld
-#      unarchive:
-#        src: https://github.com/flannel-io/flannel/releases/download/{{ flannel_version }}/flannel-{{ flannel_version }}-linux-amd64.tar.gz
-#        creates: /opt/bin/flanneld
-#        dest: /opt/bin
-#        remote_src: yes
     - name: Create flannel deployment file
       template:
         src: kube-flannel.yml.j2
-        dest: /opt/flannel/kube-flannel.yml
+        dest: "{{ flannel_home }}/kube-flannel.yml"
+    #
+    # Undo the kubeadm installation. Assume that ../cluster/down.sh is executed
+    # before.
+    #
+    - name: Uninstall kubeadm
+      tags: undo
+      block:
+        - name: Uninstall flannel
+          file:
+            path: "{{ flannel_home }}"
+            state: absent
+        - name: Stop kubelet service
+          service:
+            name: kubelet
+            state: stopped
+        - name: Delete kubelet service files
+          file:
+            path: "{{ item }}"
+            state: absent
+          with_items:
+            - "{{ kubelet_service_file }}"
+            - "{{ kubelet_service_dir }}"
+        - name: Delete the kubeadm configuration directory
+          file:
+            path: "{{ kubeadm_conf_dir }}"
+            state: absent
+        - name: Remove kube binaries
+          file:
+            path: "/usr/local/bin/{{ item }}"
+            state: absent
+          with_items:
+            - crictl
+            - kubeadm
+            - kubectl
+            - kubelet
+        - name: Uninstall cni
+          file:
+            path: "{{ cni_home }}"
+            state: absent
+        # TODO: what to do with swap?

--- a/tests/e2e/ansible/install_test_deps.yml
+++ b/tests/e2e/ansible/install_test_deps.yml
@@ -1,0 +1,27 @@
+# Install the test dependencies.
+#
+---
+- hosts: all
+  become: yes
+  tasks:
+    - name: Install test dependencies
+      package:
+        name:
+          - bats
+          - jq
+        state: present
+    - block:
+      - name: Download and extract Go tarball
+        unarchive:
+          # TODO: use facts
+          src: https://go.dev/dl/go{{ go_version }}.linux-amd64.tar.gz
+          creates: /usr/local/go
+          dest: /usr/local
+          remote_src: yes
+        register: go_install
+      - name: Create link to go binary
+        file:
+          src: /usr/local/go/bin/go
+          dest: /usr/local/bin/go
+          state: link
+        when: go_install.changed == True

--- a/tests/e2e/ansible/install_test_deps.yml
+++ b/tests/e2e/ansible/install_test_deps.yml
@@ -25,3 +25,16 @@
           dest: /usr/local/bin/go
           state: link
         when: go_install.changed == True
+    #
+    # Undo the installation.
+    #
+    - name: Uninstall test dependencies
+      tags: undo
+      block:
+        - name: Uninstall go
+          file:
+            path: "{{ item }}"
+            state: absent
+          with_items:
+            - /usr/local/bin/go
+            - /usr/local/go

--- a/tests/e2e/ansible/main.yml
+++ b/tests/e2e/ansible/main.yml
@@ -1,0 +1,17 @@
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This the main entry point to bootstrap the test environment.
+#
+---
+- name: Install build dependencies
+  import_playbook: install_build_deps.yml
+- name: Install and configure containerd
+  import_playbook: install_containerd.yml
+# TODO: import either containerd or crio 
+#  when: container_runtime is 'containerd'
+- name: Install and configure kubeadm
+  import_playbook: install_kubeadm.yml
+- name: Start a local docker registry
+  import_playbook: start_docker_registry.yml

--- a/tests/e2e/ansible/main.yml
+++ b/tests/e2e/ansible/main.yml
@@ -15,3 +15,5 @@
   import_playbook: install_kubeadm.yml
 - name: Start a local docker registry
   import_playbook: start_docker_registry.yml
+- name: Install test dependencies
+  import_playbook: install_test_deps.yml

--- a/tests/e2e/ansible/start_docker_registry.yml
+++ b/tests/e2e/ansible/start_docker_registry.yml
@@ -10,6 +10,7 @@
   become: yes
   vars:
     local_registry_port: 5000
+    local_registry_name: local-registry
   tasks:
     - name: Install pip3
       package:
@@ -22,9 +23,19 @@
         name: docker
     - name: Start a docker registry
       docker_container:
-        name: local-registry
+        name: "{{ local_registry_name }}"
         # TODO: docker.io is troublesome as we can hit the pull limits.
         image: docker.io/library/registry:latest
         ports:
           - "{{ local_registry_port }}:{{ local_registry_port }}"
         state: started
+    #
+    # Remove the docker registry container.
+    #
+    - name: Remove the docker registry container
+      tags: undo
+      block:
+        - name: Remove the docker registry
+          docker_container:
+            name: "{{ local_registry_name }}"
+            state: absent

--- a/tests/e2e/ansible/start_docker_registry.yml
+++ b/tests/e2e/ansible/start_docker_registry.yml
@@ -1,0 +1,30 @@
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start a docker registry server on the host. It will be used to store the
+# operator images.
+#
+---
+- hosts: all
+  become: yes
+  vars:
+    local_registry_port: 5000
+  tasks:
+    - name: Install pip3
+      package:
+        # TODO: this is ubuntu specific...
+        name: python3-pip
+        state: present
+    # The docker pip is needed by the docker_container ansible module itself.
+    - name: Install docker pip
+      pip:
+        name: docker
+    - name: Start a docker registry
+      docker_container:
+        name: local-registry
+        # TODO: docker.io is troublesome as we can hit the pull limits.
+        image: docker.io/library/registry:latest
+        ports:
+          - "{{ local_registry_port }}:{{ local_registry_port }}"
+        state: started

--- a/tests/e2e/ansible/templates/10-kubeadm.conf.j2
+++ b/tests/e2e/ansible/templates/10-kubeadm.conf.j2
@@ -1,0 +1,12 @@
+# Copied and modified from https://raw.githubusercontent.com/kubernetes/release/v0.4.0/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf
+# Note: This dropin only works with kubeadm and kubelet v1.11+
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart={{ kubelet_bin }} $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS

--- a/tests/e2e/ansible/templates/kube-flannel.yml.j2
+++ b/tests/e2e/ansible/templates/kube-flannel.yml.j2
@@ -1,0 +1,205 @@
+# Copied and modified from https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kube-flannel
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-flannel
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: kube-flannel
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-flannel
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-flannel
+  labels:
+    tier: node
+    app: flannel
+spec:
+  selector:
+    matchLabels:
+      app: flannel
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      initContainers:
+      - name: install-cni-plugin
+       #image: flannelcni/flannel-cni-plugin:v1.1.0 for ppc64le and mips64le (dockerhub limitations may apply)
+        image: docker.io/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
+        command:
+        - cp
+        args:
+        - -f
+        - /flannel
+        - /opt/cni/bin/flannel
+        volumeMounts:
+        - name: cni-plugin
+          mountPath: /opt/cni/bin
+      - name: install-cni
+       #image: flannelcni/flannel:v0.19.1 for ppc64le and mips64le (dockerhub limitations may apply)
+        image: docker.io/rancher/mirrored-flannelcni-flannel:v0.19.1
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conflist
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      containers:
+      - name: kube-flannel
+       #image: flannelcni/flannel:v0.19.1 for ppc64le and mips64le (dockerhub limitations may apply)
+        image: docker.io/rancher/mirrored-flannelcni-flannel:v0.19.1
+        command:
+        - /opt/bin/flanneld
+        args:
+        - --ip-masq
+        - --kube-subnet-mgr
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: false
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: EVENT_QUEUE_DEPTH
+          value: "5000"
+        volumeMounts:
+        - name: run
+          mountPath: /run/flannel
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+      volumes:
+      - name: run
+        hostPath:
+          path: /run/flannel
+      - name: cni-plugin
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: flannel-cfg
+        configMap:
+          name: kube-flannel-cfg
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate

--- a/tests/e2e/ansible/templates/kubeadm.conf.j2
+++ b/tests/e2e/ansible/templates/kubeadm.conf.j2
@@ -1,0 +1,35 @@
+# Copied and modified from https://github.com/kata-containers/tests/blob/main/integration/kubernetes/kubeadm/config.yaml
+#
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: InitConfiguration
+nodeRegistration:
+  criSocket: {{ kubeadm_cri_runtime_socket }}
+  kubeletExtraArgs:
+    allowed-unsafe-sysctls: kernel.msg*,kernel.shm.*,net.*
+    v: "4"
+---
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+kubernetesVersion: {{ k8s_version }}
+networking:
+  dnsDomain: cluster.local
+  podSubnet: 10.244.0.0/16
+  serviceSubnet: 10.96.0.0/12
+apiServer:
+  extraArgs:
+    feature-gates: PodOverhead=true
+scheduler:
+  extraArgs:
+    feature-gates: PodOverhead=true
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: {{ kubelet_cgroup_driver }}
+featureGates:
+  PodOverhead: true
+systemReserved:
+  cpu: 500m
+  memory: 256Mi
+kubeReserved:
+  cpu: 500m
+  memory: 256Mi

--- a/tests/e2e/ansible/templates/kubelet.service.j2
+++ b/tests/e2e/ansible/templates/kubelet.service.j2
@@ -1,0 +1,16 @@
+# Copied from https://raw.githubusercontent.com/kubernetes/release/v0.4.0/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service
+#
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart={{ kubelet_bin }}
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/e2e/cluster/down.sh
+++ b/tests/e2e/cluster/down.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+
+# Run kubeadm reset to clean up as much as possible the installed cluster.
+#
+reset_kubeadm() {
+	# TODO: make it configurable.
+	local cri_runtime_socket="/run/containerd/containerd.sock"
+
+	kubeadm reset -f --cri-socket="${cri_runtime_socket}"
+
+	# kubectl -n kube-system get cm kubeadm-config -o yaml
+	rm -rf ~/.kube/ || true
+
+	# TODO: recover iptables
+	#
+	# The reset process does not reset or clean up iptables rules or IPVS tables.
+        # If you wish to reset iptables, you must do so manually by using the "iptables" command.
+        #If your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar) to reset your system's IPVS tables.
+
+}
+
+remove_cni() {
+	local dev="cni0"
+
+	rm -rf /etc/cni/net.d
+	ip link set dev "$dev" down || true
+	ip link del "$dev" || true
+}
+
+remove_flannel() {
+	local dev="flannel.1"
+
+	ip link set dev "$dev" down || true
+	ip link del "$dev" || true
+}
+
+main() {
+	reset_kubeadm
+	remove_cni
+	remove_flannel
+}
+
+main "$@"

--- a/tests/e2e/cluster/up.sh
+++ b/tests/e2e/cluster/up.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+
+source "${script_dir}/../lib.sh"
+
+# Run kubeadm init and KUBECONFIG is exported on success.
+#
+init_kubeadm() {
+	local kubeadm_config_file="/etc/kubeadm/kubeadm.conf"
+	# Bootstrap the control-plane node.
+	kubeadm init --config "${kubeadm_config_file}"
+
+	export KUBECONFIG=/etc/kubernetes/admin.conf
+
+	# TODO: if we want to run as a regular user.
+	#mkdir -p $HOME/.kube
+	#sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+	#sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+	# TODO: wait node to show up
+	#kubectl get nodes
+}
+
+# Configure the cluster network with flannel.
+#
+configure_flannel() {
+	local flannel_ns="kube-flannel"
+
+	kubectl apply -f /opt/flannel/kube-flannel.yml
+
+	if ! wait_pods "$flannel_ns"; then
+		echo "ERROR: pods didn't show up in $flannel_ns"
+		return 1
+	fi
+
+	if ! check_pods_are_ready "$flannel_ns" 120; then
+		echo "ERROR: flannel pods are not ready"
+		return 1
+	fi
+	# TODO: check coredns is up and running too
+}
+
+main() {
+	init_kubeadm
+	configure_flannel
+	check_node_is_ready
+
+	# Untaint the node so that pods can be scheduled on it.
+	for role in master control-plane; do
+		kubectl taint nodes "$(hostname)" \
+			"node-role.kubernetes.io/$role:NoSchedule-"
+	done
+}
+
+main "$@"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Wait until the node is ready. It is set a timeout of 180 seconds.
+#
+check_node_is_ready() {
+	wait_for_process 180 10 "kubectl get nodes | grep -q '\<Ready\>'"
+}
+
+# Check that all pods running on a given namespace are ready.
+#
+# Parameters:
+#	$1 - the namespace
+#	$2 - timeout in seconds to check each pod (default to 30)
+#
+check_pods_are_ready() {
+	local ns="$1"
+	# Some pods take longer than the default 30s.
+	local timeout="${2:-30}s"
+
+	local pods=($(kubectl get -n "$ns" pods \
+		-o jsonpath='{.items[*].metadata.name}'))
+
+	# At least one pod is expected.
+	if [ ${#pods[@]} -eq 0 ]; then
+		echo "ERROR: no pods found in $ns"
+		return 1
+	fi
+
+	for p in ${pods[@]}; do
+		kubectl wait "--timeout=$timeout" -n "$ns" \
+			--for=condition=Ready "pod/${p}" >/dev/null
+	done
+}
+
+# Wait for at least one pod to show up on the namespace.
+#
+# Parameters:
+#	$1 - the namespace
+#	$2 - (optional) wait time in seconds between each checking
+#	     (default to 10)
+#	$3 - (optional) checking counter (default to 6)
+#
+wait_pods() {
+	local ns="$1"
+	local wait_time="${2:-10}"
+	local cnt="${3:-6}"
+
+	local cmd="kubectl get pods -n "$ns" -o jsonpath='{.items[*].metadata.name}' || true"
+	local pods=($(eval $cmd))
+	while [ "${#pods[@]}" -eq 0 -a "$cnt" -gt 0 ]; do
+		sleep "$wait_time"
+		cnt=$(($cnt-1))
+		pods=($(eval $cmd))
+	done
+	[ "${#pods[@]}" -gt 0 ]
+}
+
+# Wait until the command exit with success.
+#
+# Parameters:
+#	$1 - the total wait time
+#	$2 - the sleep time between runs
+#	$3 - the command to run
+#
+# Note: copied from kata-containers/tests/lib/common.bash
+#
+wait_for_process() {
+	wait_time="$1"
+	sleep_time="$2"
+	cmd="$3"
+	while [ "$wait_time" -gt 0 ]; do
+		if eval "$cmd"; then
+			return 0
+		else
+			sleep "$sleep_time"
+			wait_time=$((wait_time-sleep_time))
+		fi
+	done
+	return 1
+}

--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -102,8 +102,8 @@ start_local_registry() {
 #
 uninstall_operator() {
 	pushd "$project_dir" >/dev/null
-	make uninstall
-	make undeploy
+	make uninstall ignore-not-found=true
+	make undeploy ignore-not-found=true
 	popd >/dev/null
 }
 

--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+project_dir="$(readlink -f ${script_dir}/../..)"
+
+source "${script_dir}/lib.sh"
+
+# The operator namespace.
+readonly op_ns="confidential-containers-system"
+# There should be a registry running locally on port 5000.
+export IMG=localhost:5000/cc-operator
+
+# Build the operator and push images to a local registry.
+#
+build_operator () {
+	start_local_registry
+
+	pushd "$project_dir" >/dev/null
+	make docker-build
+	make docker-push
+	popd >/dev/null
+}
+
+# Install the operator.
+#
+install_operator() {
+	start_local_registry
+
+	# The node should be 'worker' labeled
+	local label="node-role.kubernetes.io/worker"
+	if ! kubectl get node "$(hostname)" -o jsonpath='{.metadata.labels}' \
+		| grep -q "$label"; then
+		kubectl label node "$(hostname)" "$label="
+	fi
+
+	pushd "$project_dir" >/dev/null
+	make install
+	# TODO: need any checking after install?
+	make deploy
+	popd >/dev/null
+
+	# Wait the operator controller to be running.
+	local cmd="kubectl get pods -n "$op_ns" --no-headers |"
+	cmd+="egrep -q cc-operator-controller-manager.*'\<Running\>'"
+	if ! wait_for_process 120 10 "$cmd"; then
+		echo "ERROR: operator-controller-manager pod is not running"
+		return 1
+	fi
+}
+
+# Install the CC runtime.
+#
+install_ccruntime() {
+	pushd "$project_dir" >/dev/null
+	kubectl create -f config/samples/ccruntime.yaml
+	popd >/dev/null
+
+	local pod=""
+	local cmd=""
+	for pod in cc-operator-daemon-install cc-operator-pre-install-daemon; do
+		cmd="kubectl get pods -n "$op_ns" --no-headers |"
+		cmd+="egrep -q ${pod}.*'\<Running\>'"
+		if ! wait_for_process 600 30 "$cmd"; then
+			echo "ERROR: $pod pod is not running"
+			return 1
+		fi
+	done
+
+	# TODO: check the runtime is up.
+	# kubectl get runtimeclass
+}
+
+# Start a local registry where images can be stored.
+# The ansible playbooks should start it however it can get stopped when,
+# for example, the operator is unistalled.
+#
+start_local_registry() {
+	# TODO: allow callers to override the container name, port..etc
+	local registry_container="local-registry"
+
+	if ! curl -s localhost:5000; then
+		docker start local-registry >/dev/null
+		local cnt=0
+		while ! curl -s localhost:5000 -o $cnt -lt 5; do
+			sleep 1
+			cnt=$(($cnt+1))
+		done
+		[ $cnt -ne 5 ]
+	fi
+}
+
+# Uninstall the operator and ccruntime.
+#
+uninstall_operator() {
+	pushd "$project_dir" >/dev/null
+	make uninstall
+	make undeploy
+	popd >/dev/null
+}
+
+usage() {
+	cat <<-EOF
+	Utility to build/install/uninstall the operator.
+
+	Use: $0 [-h|--help] [command], where:
+	-h | --help : show this usage
+	command : optional command (build and install by default). Can be:
+	 "build": build only,
+	 "install": install only,
+	 "uninstall": uninstall the operator.
+	EOF
+}
+
+main() {
+	if [ $# -eq 0 ]; then
+		build_operator
+		install_operator
+		install_ccruntime
+	else
+		case $1 in
+			-h|--help) usage && exit 0;;
+			build) build_operator;;
+			install)
+				install_operator
+				install_ccruntime
+				;;
+			uninstall) uninstall_operator;;
+			*)
+				echo "Unknown command '$1'"
+				usage && exit 1
+		esac
+	fi
+}
+
+main "$@"

--- a/tests/e2e/operator_tests.bats
+++ b/tests/e2e/operator_tests.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Operator specfic tests.
+#
+load "${BATS_TEST_DIRNAME}/lib.sh"
+test_tag="[cc][operator]"
+
+is_operator_installed() {
+	[ "$(kubectl get deployment -n "$ns" --no-headers 2>/dev/null | wc -l)" \
+		-gt 0 ]
+}
+
+setup() {
+	container_runtime="${container_runtime:-containerd}"
+	ns="confidential-containers-system"
+}
+
+@test "$test_tag Test can uninstall the operator" {
+
+# Assume the operator is installed, otherwise fail.
+is_operator_installed
+
+"${BATS_TEST_DIRNAME}/operator.sh" uninstall
+
+# TODO: this check is not passing as we need to update the payload.
+#
+# It should remove the kata containers installation entirely.
+#[ ! -d "/opt/confidential-containers" ]
+
+# It should let the container runtime running.
+systemctl is-active "$container_runtime"
+}
+
+teardown() {
+	# If any test removes the operator, let's ensure it is re-installed.
+	is_operator_installed || "${BATS_TEST_DIRNAME}/operator.sh" install
+}

--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+
+usage() {
+	cat <<-EOF
+	$0: run the end-to-end tests on local host.
+
+	It requires Ansible to run.
+	Important: it will change the system so ensure it is executed in a development
+	environment.
+	EOF
+}
+
+parse_args() {
+	while getopts "h" opt; do
+		case $opt in
+			h) usage && exit 0;;
+			*) usage && exit 1;;
+		esac
+	done
+}
+
+main() {
+	parse_args $@
+
+	# Check Ansible is installed.
+	if ! command -v ansible-playbook >/dev/null; then
+		echo "ERROR: ansible-playbook is required to run this script."
+		exit 1
+	fi
+
+	pushd "$script_dir" >/dev/null
+	echo "INFO: Bootstrap the local machine"
+	ansible-playbook -i localhost, -c local ansible/main.yml
+
+	echo "INFO: Bring up the test cluster"
+	sudo ./cluster/up.sh
+	export KUBECONFIG=/etc/kubernetes/admin.conf
+
+	echo "INFO: Build and install the operator"
+	sudo -E PATH="$PATH" ./operator.sh
+
+	echo "INFO: Run tests"
+	sudo -E PATH="$PATH" ./tests_runner.sh
+	popd >/dev/null
+}
+
+main "$@"

--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -10,6 +10,8 @@ set -o pipefail
 
 script_dir="$(dirname "$(readlink -f "$0")")"
 
+undo="false"
+
 usage() {
 	cat <<-EOF
 	$0: run the end-to-end tests on local host.
@@ -21,13 +23,32 @@ usage() {
 }
 
 parse_args() {
-	while getopts "h" opt; do
+	while getopts "hu" opt; do
 		case $opt in
 			h) usage && exit 0;;
+			u) undo="true";;
 			*) usage && exit 1;;
 		esac
 	done
 }
+
+undo_changes() {
+	# TODO: in case the script failed, we should undo only the steps
+	# executed.
+	pushd "$script_dir" >/dev/null
+	sudo -E PATH="$PATH" ./operator.sh uninstall || true
+	sudo -E PATH="$PATH" ./cluster/down.sh || true
+	ansible-playbook -i localhost, -c local --tags undo ansible/main.yml || true
+	popd
+}
+
+on_exit() {
+	if [ "$undo" == "true" ]; then
+		undo_changes
+	fi
+}
+
+trap on_exit EXIT
 
 main() {
 	parse_args $@
@@ -40,7 +61,7 @@ main() {
 
 	pushd "$script_dir" >/dev/null
 	echo "INFO: Bootstrap the local machine"
-	ansible-playbook -i localhost, -c local ansible/main.yml
+	ansible-playbook -i localhost, -c local --tags untagged ansible/main.yml
 
 	echo "INFO: Bring up the test cluster"
 	sudo ./cluster/up.sh

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+project_dir="$(readlink -f ${script_dir}/../..)"
+
+export GOPATH="$(mktemp -d)"
+tests_repo_dir="$GOPATH/src/github.com/kata-containers/tests"
+export CI=true
+
+# TODO: Debug should be enabled in order for some tests to enable the console
+# debug and search for patterns on agent logs. Probably console debug should
+# be enabled always.
+export DEBUG=true
+
+# TODO: some tests use the SKOPEO variable (which is a build time variable) to
+# decide whether run or not. This should be no longer the case when we replace
+# skopeo with image-rs.
+export SKOPEO=yes
+echo "IMPORTANT: Assume the image was built with SKOPEO=${SKOPEO}"
+
+# Tests will attempt to re-configure containerd. In our case it is already
+# proper set by the operator, so let's skip that step.
+export TESTS_CONFIGURE_CC_CONTAINERD=no
+
+clone_kata_tests() {
+	local cc_branch="CCv0"
+
+	# TODO: checkout on the exact sha1 where the kata-deploy was created
+	# so that we ensure the same tests are used here.
+	git clone --branch="$cc_branch" \
+		https://github.com/kata-containers/tests "$tests_repo_dir"
+}
+
+cleanup() {
+	unlink /usr/local/bin/kata-runtime || true
+	rm -rf "$tests_repo_dir" || true
+}
+
+trap cleanup EXIT
+
+main() {
+
+	clone_kata_tests
+
+	cd "${tests_repo_dir}/integration/kubernetes/confidential"
+
+	# Test scripts rely on kata-runtime so it should be reacheable on PATH.
+	# Re-export PATH is error prone as some calls to kata-runtime use sudo,
+	# so let's create a symlink.
+	ln -sf /opt/confidential-containers/bin/kata-runtime \
+		/usr/local/bin/kata-runtime
+
+	# Run tests.
+
+	# Results for agent_image.bats:
+	#
+	# ok 1 [cc][agent][kubernetes][containerd] Test can pull an unencrypted image inside the guest
+	# ok 2 [cc][agent][kubernetes][containerd] Test can pull a unencrypted signed image from a protected registry
+	# not ok 3 [cc][agent][kubernetes][containerd] Test cannot pull an unencrypted unsigned image from a protected registry
+	# ok 4 [cc][agent][kubernetes][containerd] Test can pull an unencrypted unsigned image from an unprotected registry
+	# not ok 5 [cc][agent][kubernetes][containerd] Test unencrypted signed image with unknown signature is rejected
+
+	# Results for agent_image_encrypted.bats
+	#
+	# ok 1 [cc][agent][kubernetes][containerd] Test can pull an encrypted image inside the guest with decryption key
+	# ok 2 [cc][agent][kubernetes][containerd] Test cannot pull an encrypted image inside the guest without decryption key
+
+	local tests_passing="Test can pull an unencrypted image inside the guest"
+	tests_passing+="|Test can pull a unencrypted signed image from a protected registry"
+	tests_passing+="|Test can pull an unencrypted unsigned image from an unprotected registry"
+	tests_passing+="|Test cannot pull an encrypted image inside the guest without decryption key"
+	tests_passing+="|Test can pull an encrypted image inside the guest with decryption key"
+
+	bats -f "$tests_passing" agent_image.bats agent_image_encrypted.bats
+}
+
+main "$@"

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -79,8 +79,12 @@ main() {
 	tests_passing+="|Test can pull an unencrypted unsigned image from an unprotected registry"
 	tests_passing+="|Test cannot pull an encrypted image inside the guest without decryption key"
 	tests_passing+="|Test can pull an encrypted image inside the guest with decryption key"
+	tests_passing+="|Test can uninstall the operator"
 
-	bats -f "$tests_passing" agent_image.bats agent_image_encrypted.bats
+	bats -f "$tests_passing" \
+		"agent_image.bats" \
+		"agent_image_encrypted.bats" \
+		"${script_dir}/operator_tests.bats"
 }
 
 main "$@"


### PR DESCRIPTION
Adds ansible playbooks to setup the test environment. Kubernetes will be
deployed with kubeadm.

The cluster/up.sh is used to bring up the cluster. Afterwards run
build_install_operator.sh to build and install the operator and
ccruntime. Notice it pushes the operator's controller image to a docker
registry running locally so we avoid pushing/pulling to/from quay.io.

I tested in a Fedora 34 x86_64 machine in a Vagrant VM (see the
Vagrantfile added in this commit). If you wish to run likewise:

$ cd tests/e2e
$ vagrant up tests-e2e-ubuntu2004

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>