### PR TITLE
build: ignore crd not found in uninstall/undeploy targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = false
+  ignore-not-found = true
 endif
 
 .PHONY: install


### PR DESCRIPTION
uninstall and undeploy targets both want to delete the CCRuntimeConfig
CRD. When we call these targets one after another the second one will
always fail. This is because we add 'ignore-not-found=false' when we
call `kubectl delete`.

It is safe to set `ignore-not-found=true` in the undelete/undeploy case
because if a resource is not there we don't have to delete it.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>