### PR TITLE
bundle,config: Update pre/post image

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -111,7 +111,7 @@ metadata:
               ],
               "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-e8902bb373727d282f1ba7612056f671b8096ee4"
               "postUninstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",
@@ -162,7 +162,7 @@ metadata:
                 ]
               },
               "preInstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",

--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -52,7 +52,7 @@ spec:
     uninstallCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "cleanup"]
     cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
     postUninstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
@@ -80,7 +80,7 @@ spec:
             type: ""
           name: systemd
     preInstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts


### PR DESCRIPTION
Let's update the pre/post hooks image to point to the latest version of
the container-engine-for-cc-payload.

The changes in the container-engine-for-cc-payload are:
* Removing `/opt/confidential-containers` as part of the uninstall
  target.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>