### PR TITLE
bundle,config: Update Kata Containers payload

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
               ],
               "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-f5a65223989b090c91e94faf933ce256fc6e6c9b",
               "postUninstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",
@@ -157,7 +157,7 @@ metadata:
                 ]
               },
               "preInstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",

--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -104,7 +104,7 @@ metadata:
                   "name": "local-bin"
                 }
               ],
-              "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-e8902bb373727d282f1ba7612056f671b8096ee4",
+              "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-f5a65223989b090c91e94faf933ce256fc6e6c9b",
               "postUninstall": {
                 "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458",
                 "volumeMounts": [

--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -55,7 +55,7 @@ spec:
     # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
     runtimeClassNames: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx"]
     postUninstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
@@ -83,7 +83,7 @@ spec:
             type: ""
           name: systemd
     preInstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts

--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -11,7 +11,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers-e8902bb373727d282f1ba7612056f671b8096ee4
+    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers-f5a65223989b090c91e94faf933ce256fc6e6c9b
     installDoneLabel:
       katacontainers.io/kata-runtime: "true"
     uninstallDoneLabel:
@@ -53,7 +53,7 @@ spec:
     cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
     # Uncomment and add the required RuntimeClassNames to be created
     # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
-    #runtimeClassNames: ["rc1", "rc2"]
+    runtimeClassNames: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx"]
     postUninstall:
       image: quay.io/confidential-containers/container-engine-for-cc-payload:2022090517241662391458
       volumeMounts:


### PR DESCRIPTION
Let's update the Kata Containers payload to its latest build, which is
based on the commit f5a65223989b090c91e94faf933ce256fc6e6c9b.

The most significant changes which are part of this new image are:
* TDX support

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>