### PR TITLE
bundle,config: Update pre-install / post-uninstall image

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
               ],
               "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-f5a65223989b090c91e94faf933ce256fc6e6c9b",
               "postUninstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",
@@ -157,7 +157,7 @@ metadata:
                 ]
               },
               "preInstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",

--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -104,7 +104,7 @@ metadata:
                   "name": "local-bin"
                 }
               ],
-              "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-f5a65223989b090c91e94faf933ce256fc6e6c9b",
+              "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-b11b6e3756a15e602a5bff1d4d47da8ecf23c593",
               "postUninstall": {
                 "image": "quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62",
                 "volumeMounts": [

--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -55,7 +55,7 @@ spec:
     # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
     runtimeClassNames: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx"]
     postUninstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
@@ -83,7 +83,7 @@ spec:
             type: ""
           name: systemd
     preInstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:2022070719511657216287
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts

--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -11,7 +11,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers-f5a65223989b090c91e94faf933ce256fc6e6c9b
+    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers-b11b6e3756a15e602a5bff1d4d47da8ecf23c593
     installDoneLabel:
       katacontainers.io/kata-runtime: "true"
     uninstallDoneLabel:


### PR DESCRIPTION
Thanks to our new CI, we've found that the previous update of the pre-install / post-uninstall image actually introduced a regression in the Operator, as the script would fail trying to remove a non-empty `/opt/confidential-containers` directory.

The main changes in this version of the image are:
* Fixes a bug on uninstall, where we'd try to remove containerd while
  its binary was still being used
* Includes more debug messages
* Uses a commit id as the image tag, instead of the time the image was
  built, in order to make it easier to link an image to the code.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>