### PR TITLE
ci: added reinstall operator test

### DIFF
--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -43,9 +43,7 @@ install_operator() {
 	fi
 
 	pushd "$project_dir" >/dev/null
-	make install
-	# TODO: need any checking after install?
-	make deploy
+	kubectl apply -f deploy/deploy.yaml
 	popd >/dev/null
 
 	# Wait the operator controller to be running.
@@ -102,8 +100,8 @@ start_local_registry() {
 #
 uninstall_operator() {
 	pushd "$project_dir" >/dev/null
-	make uninstall ignore-not-found=true
-	make undeploy ignore-not-found=true
+	kubectl delete -f config/samples/ccruntime.yaml
+	kubectl delete -f deploy/deploy.yaml
 	popd >/dev/null
 }
 

--- a/tests/e2e/operator_tests.bats
+++ b/tests/e2e/operator_tests.bats
@@ -34,7 +34,14 @@ is_operator_installed
 systemctl is-active "$container_runtime"
 }
 
+@test "$test_tag Test can reinstall the operator" {
+# Assume the previous test (which removes the operator) passed.
+! is_operator_installed
+
+"${BATS_TEST_DIRNAME}/operator.sh" install
+}
+
 teardown() {
-	# If any test removes the operator, let's ensure it is re-installed.
-	is_operator_installed || "${BATS_TEST_DIRNAME}/operator.sh" install
+	# For debugging sake.
+	kubectl get pods -A || true
 }

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -134,6 +134,7 @@ main() {
 	tests_passing+="|Test cannot pull an encrypted image inside the guest without decryption key"
 	tests_passing+="|Test can pull an encrypted image inside the guest with decryption key"
 	tests_passing+="|Test can uninstall the operator"
+	tests_passing+="|Test can reinstall the operator"
 
 	bats -f "$tests_passing" \
 		"agent_image.bats" \


### PR DESCRIPTION
This break the operator tests in two:

- one that will uninstall the operator. On teardown() it no longer attempt to reinstall the operator.
- and one that will try to reinstall the operator. It assumes the first test ran before and passed.
---
 ci: change the install/uninstall commands

The commands to uninstall the entire thing (make uninstall && make
undeploy) seems to the sometimes the CI job stuck. We recommend adopters
to use the commands in docs/INSTALL.md, so let's use them on CI as well.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>