### PR TITLE
config: add kata-qemu-sev runtimeclass

### DIFF
--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -53,8 +53,8 @@ spec:
     cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
     # Uncomment and add the required RuntimeClassNames to be created
     # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
-    runtimeClassNames:
-      ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx"]
+    runtimeClassNames: 
+      ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx", "kata-qemu-sev"]
     postUninstall:
       image: quay.io/confidential-containers/container-engine-for-cc-payload:4892b726eaf15e3932dd7990e196e92bd6f964d5
       volumeMounts:


### PR DESCRIPTION
Adding runtimeclass for sev. 

Depends on sev kata PRs:

- Packaging for initrd: https://github.com/kata-containers/kata-containers/pull/5120
- Packaging for OVMF: https://github.com/kata-containers/kata-containers/pull/5026
- Packaging for SEV-capable kernel + kernel module https://github.com/kata-containers/kata-containers/pull/5038
- Add agent config to rootfs: https://github.com/kata-containers/kata-containers/pull/5024
- Use depmod in rootfs builder on kernel module(s): https://github.com/kata-containers/kata-containers/pull/5127
- Kata-deploy add kata-qemu-sev shim/runtimeclas https://github.com/kata-containers/kata-containers/pull/5130

Integration testing of all of the SEV components has been successful. Made a cc bundle with all of the PRs added to base CCv0, converted to a docker container via the kata-deploy-cc docker script, and deployed to quay. Was able to run a pod after being deployed with the operator.

@fidencio @fitzthum @wainersm 

Signed-off-by: Alex Carter <Alex.Carter@ibm.com>