### PR TITLE
Switch between tests based on runtime class 

### DIFF
--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -48,11 +48,6 @@ cleanup() {
 	[ ! -s "/usr/local/bin/kata-runtime" ] || \
 		unlink /usr/local/bin/kata-runtime
 	rm -rf "$tests_repo_dir" || true
-
-	# Restore the configuration.toml to its default value.
-	if [ "$runtimeclass" != "kata-qemu" ];then
-		set_kata_config "kata-qemu"
-	fi
 }
 
 trap cleanup EXIT
@@ -67,41 +62,20 @@ parse_args() {
 	done
 }
 
-set_kata_config() {
-	local runtimeclass="$1"
-	# Remove "kata-" prefix to get the name of the configuration file.
-	local kata_config="$(echo "$runtimeclass" | sed 's/^kata-//g')"
-	local kata_config_dir="/opt/confidential-containers/share/defaults/kata-containers/"
-	local default_config_link="${kata_config_dir}/configuration.toml"
-	local config_file="${kata_config_dir}/configuration-${kata_config}.toml"
-
-	if [ ! -f "$config_file" ]; then
-		echo "ERROR: Kata configuration file does exist: $config_file"
-		return 1
-	fi
-
-	[ ! -s "$default_config_link" ] || unlink "$default_config_link"
-	ln -s "$config_file" "$default_config_link"
-}
-
 usage() {
 	cat <<-EOF
 	Utility to run the tests.
 
 	Use: $0 [-h|--help] [-r RUNTIMECLASS], where:
 	-h | --help : show this usage
-	-r RUNTIMECLASS: configure to use the RUNTIMECLASS (e.g. kata-clh) on
-	                 the tests. Defaults to "kata-qemu".
+	-r RUNTIMECLASS: run tests for RUNTIMECLASS (e.g. kata-clh).
+	                 Defaults to "kata-qemu".
 	EOF
 }
 
 main() {
 
 	parse_args $@
-
-	if [ "$runtimeclass" != "kata-qemu" ];then
-		set_kata_config "$runtimeclass"
-	fi
 
 	clone_kata_tests
 


### PR DESCRIPTION
Rather than using the RUNTIMECLASS parameter to modify the contained config, use it to switch between different test files. These tests will then use the appropriate runtime class. The runtime class is a good way to identify different tests because it includes the hypervisor and the hardware that are supported.

This also adds the SEV tests that @ryansavino is working on. See https://github.com/kata-containers/tests/pull/5130

Depends on https://github.com/confidential-containers/operator/pull/80 for  the runtime class.

At some point in the future we might want a more robust way to link test file names to rurntime classes. It's also a bit annoying that we have to specify the names of each of the tests in this repo. That will mean we need extra changes when we push new tests to the tests repo.

@wainersm