### PR TITLE
Install bats from upstream 

### DIFF
--- a/tests/e2e/ansible/install_test_deps.yml
+++ b/tests/e2e/ansible/install_test_deps.yml
@@ -7,7 +7,6 @@
     - name: Install test dependencies
       package:
         name:
-          - bats
           - jq
         state: present
     - block:
@@ -25,6 +24,21 @@
           dest: /usr/local/bin/go
           state: link
         when: go_install.changed == True
+    - block:
+      - name: Clone upstream Bats source
+        git:
+          repo: https://github.com/bats-core/bats-core.git
+          dest: /tmp/bats-core
+      - name: Install Bats
+        command: ./install.sh /usr
+        args:
+          chdir: /tmp/bats-core
+          creates: /usr/bin/bats
+      - name: Remove Bats source
+        file:
+          path: /tmp/bats-core
+          state: absent
+
     #
     # Undo the installation.
     #
@@ -38,3 +52,7 @@
           with_items:
             - /usr/local/bin/go
             - /usr/local/go
+        - name: Remove Bats binary
+          file:
+            path: /usr/bin/bats
+            state: absent


### PR DESCRIPTION
Fixes #83. Based on [this script](https://github.com/kata-containers/tests/blob/main/.ci/install_bats.sh)

Idk how to use ansible so maybe there is a much nicer way to do this.

@wainersm  @ryansavino 