### PR TITLE
bundle,config: Update pre-install / post-uninstall image

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
               ],
               "payloadImage": "quay.io/confidential-containers/runtime-payload:kata-containers-b11b6e3756a15e602a5bff1d4d47da8ecf23c593",
               "postUninstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:4892b726eaf15e3932dd7990e196e92bd6f964d5",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",
@@ -157,7 +157,7 @@ metadata:
                 ]
               },
               "preInstall": {
-                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62",
+                "image": "quay.io/confidential-containers/container-engine-for-cc-payload:4892b726eaf15e3932dd7990e196e92bd6f964d5",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",

--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -55,7 +55,7 @@ spec:
     # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
     runtimeClassNames: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx"]
     postUninstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:4892b726eaf15e3932dd7990e196e92bd6f964d5
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
@@ -83,7 +83,7 @@ spec:
             type: ""
           name: systemd
     preInstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:31e1e81ceb984ed9090d5ddff39837c817814f62
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:4892b726eaf15e3932dd7990e196e92bd6f964d5
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts


### PR DESCRIPTION
A new image of container-engine-for-cc-payload (commit 4892b72 from https://github.com/fidencio/container-engine-for-cc-payload) was created to fix the post-uninstall pod that is getting stuck on terminating phase. It turned out that kubelet should not be restarted by the post-uninstall pod, otherwise it gets in a state where the pod's volumes cannot be umounted (hence it stays on terminating state forever).

Fixes #53
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>