### PR TITLE
ci: install bats from source

### DIFF
--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -22,7 +22,6 @@ kubeadm_pkgs:
 k8s_version: v1.24.0
 test_pkgs:
   ubuntu:
-    - bats
     - jq
   centos:
     - jq

--- a/tests/e2e/ansible/install_test_deps.yml
+++ b/tests/e2e/ansible/install_test_deps.yml
@@ -8,7 +8,7 @@
       package:
         name: "{{ test_pkgs[ansible_distribution | lower] }}"
         state: present
-    # bats package not available on CentOS Stream 8.
+    # Install bats from source so that we get the latest features.
     - name: Install bats from sources
       block:
         - shell: command -v bats >/dev/null 2>&1
@@ -29,7 +29,6 @@
                 path: bats-core
                 state: absent
           when: bats_exist.rc != 0
-      when: ansible_distribution == "CentOS"
     - block:
       - name: Download and extract Go tarball
         unarchive:


### PR DESCRIPTION
The bats version on Ubuntu 20.04 don't have all features we need (e.g. setup_file()), so let's build from source. On CentOS it is already built and installed from source, so just enabled it to Ubuntu as well.

Fixes #83
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>