### PR TITLE
api: accept enclave-cc runtimeName

### DIFF
--- a/api/v1beta1/ccruntime_types.go
+++ b/api/v1beta1/ccruntime_types.go
@@ -24,15 +24,8 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// +kubebuilder:validation:Enum=kata
+// +kubebuilder:validation:Enum=kata;enclave-cc
 type CcRuntimeName string
-
-const (
-	// Kata
-	KataCcRuntime CcRuntimeName = "kata"
-
-	// Other Cc Runtime
-)
 
 // CcRuntimeSpec defines the desired state of CcRuntime
 type CcRuntimeSpec struct {

--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -207,6 +207,13 @@ metadata:
                   }
                 ]
               },
+              "runtimeClassNames": [
+                "kata",
+                "kata-clh",
+                "kata-clh-tdx",
+                "kata-qemu",
+                "kata-qemu-tdx"
+              ],
               "uninstallCmd": [
                 "/opt/kata-artifacts/scripts/kata-deploy.sh",
                 "cleanup"
@@ -350,7 +357,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: controller:latest
+                image: quay.io/confidential-containers/operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/confidentialcontainers.org_ccruntimes.yaml
+++ b/bundle/manifests/confidentialcontainers.org_ccruntimes.yaml
@@ -5555,6 +5555,7 @@ spec:
               runtimeName:
                 enum:
                 - kata
+                - enclave-cc
                 type: string
             required:
             - config
@@ -5632,6 +5633,7 @@ spec:
                 description: Cc Runtime Name
                 enum:
                 - kata
+                - enclave-cc
                 type: string
               totalNodesCount:
                 description: TotalNodesCounts is the total number of worker nodes

--- a/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
+++ b/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
@@ -5556,6 +5556,7 @@ spec:
               runtimeName:
                 enum:
                 - kata
+                - enclave-cc
                 type: string
             required:
             - config
@@ -5633,6 +5634,7 @@ spec:
                 description: Cc Runtime Name
                 enum:
                 - kata
+                - enclave-cc
                 type: string
               totalNodesCount:
                 description: TotalNodesCounts is the total number of worker nodes

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: quay.io/confidential-containers/operator
   newTag: latest

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -3305,6 +3305,7 @@ spec:
               runtimeName:
                 enum:
                 - kata
+                - enclave-cc
                 type: string
             required:
             - config
@@ -3370,6 +3371,7 @@ spec:
                 description: Cc Runtime Name
                 enum:
                 - kata
+                - enclave-cc
                 type: string
               totalNodesCount:
                 description: TotalNodesCounts is the total number of worker nodes targeted by this CR


### PR DESCRIPTION
Currently, only kata is allowed as runtimeName in the API. The field is copied to CcRuntimeStatus but other than that it's unused.

The first non-kata runtime is nicknamed 'enclave-cc'. Add support for it as a runtimeName identifier.
