### PR TITLE
reconcile: use configurable namespace for the secondary resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,5 +52,10 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        env:
+        - name: CCRUNTIME_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/samples/ccruntime-ssh-demo.yaml
+++ b/config/samples/ccruntime-ssh-demo.yaml
@@ -2,7 +2,6 @@ apiVersion: confidentialcontainers.org/v1beta1
 kind: CcRuntime
 metadata:
   name: ccruntime-ssh-demo
-  namespace: confidential-containers-system
 spec:
   # Add fields here
   runtimeName: kata

--- a/config/samples/ccruntime.yaml
+++ b/config/samples/ccruntime.yaml
@@ -2,7 +2,6 @@ apiVersion: confidentialcontainers.org/v1beta1
 kind: CcRuntime
 metadata:
   name: ccruntime-sample
-  namespace: confidential-containers-system
 spec:
   # Add fields here
   runtimeName: kata

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -54,6 +54,7 @@ type CcRuntimeReconciler struct {
 	Scheme    *runtime.Scheme
 	Log       logr.Logger
 	ccRuntime *ccv1beta1.CcRuntime
+	Namespace string
 }
 
 //+kubebuilder:rbac:groups=confidentialcontainers.org,resources=ccruntimes,verbs=get;list;watch;create;update;patch;delete
@@ -653,7 +654,7 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dsName,
-			Namespace: "confidential-containers-system",
+			Namespace: r.Namespace,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -845,7 +846,7 @@ func (r *CcRuntimeReconciler) makeHookDaemonset(operation DaemonOperation) *apps
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dsName,
-			Namespace: "confidential-containers-system",
+			Namespace: r.Namespace,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
CcRuntime is a cluster scoped resource and therefore their instances do not specify any namespace info.

However, the secondary resources are namespaced. Currently, a hard- code value is used but users may want to use some other namespace.

Make the secondary resources namespace configurable using a flag and env var to the operator. By default, use the same (but have it dynamic) namespace as what the operator itself runs in.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>