### PR TITLE
run-local.sh: Add support for RHEL

### DIFF
--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -8,6 +8,9 @@ build_pkgs:
   centos:
     - make
     - gcc
+  redhat:
+    - make
+    - gcc
 container_runtime: containerd
 go_version: 1.18.5
 operator_sdk_version: v1.23.0
@@ -19,9 +22,14 @@ kubeadm_pkgs:
   centos:
     - conntrack
     - socat
+  redhat:
+    - conntrack
+    - socat
 k8s_version: v1.24.0
 test_pkgs:
   ubuntu:
     - jq
   centos:
+    - jq
+  redhat:
     - jq

--- a/tests/e2e/ansible/install_docker.yml
+++ b/tests/e2e/ansible/install_docker.yml
@@ -46,7 +46,7 @@
         state: present
       # TODO: add regular non-root users to docker group
   when: docker_exist.rc != 0 and ansible_distribution == "Ubuntu"
-- name: Handle docker installation on CentOS.
+- name: Handle docker installation on CentOS/RHEL.
   block:
     - name: Install yum-utils
       dnf:
@@ -68,4 +68,4 @@
         name: docker
         enabled: yes
         state: started
-  when: docker_exist.rc != 0 and ansible_distribution == "CentOS"
+  when: docker_exist.rc != 0 and ansible_distribution_file_variety == "RedHat"


### PR DESCRIPTION
This was tested on RHEL9.1, and makes it possible to use the script to install a test cluster.

Fixes: #97

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>