### PR TITLE
ci: Add tdx supported runtime to tests

### DIFF
--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -134,7 +134,7 @@ main() {
 
 	# Run tests.
 	case $runtimeclass in
-		kata-qemu|kata-clh)
+		kata-qemu|kata-clh|kata-qemu-tdx|kata-clh-tdx)
 			echo "INFO: Running non-TEE tests for $runtimeclass"
 			run_non_tee_tests "$runtimeclass"
 			;;


### PR DESCRIPTION
Both runtime kata-qemu-tdx and kata-clh-tdx verified with operator CI on TDX machine

Signed-off-by: Wang, Arron <arron.wang@intel.com>