### PR TITLE
tests: allow to test alternative ccruntimes

### DIFF
--- a/config/samples/ccruntime-ssh-demo.yaml
+++ b/config/samples/ccruntime-ssh-demo.yaml
@@ -1,0 +1,118 @@
+apiVersion: confidentialcontainers.org/v1beta1
+kind: CcRuntime
+metadata:
+  name: ccruntime-ssh-demo
+  namespace: confidential-containers-system
+spec:
+  # Add fields here
+  runtimeName: kata
+  ccNodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+  config:
+    installType: bundle
+    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers-ssh-demo-03965fd37ac5eb75a72768ee36ab901865656944
+    installDoneLabel:
+      katacontainers.io/kata-runtime: "true"
+    uninstallDoneLabel:
+      katacontainers.io/kata-runtime: "cleanup"
+    installerVolumeMounts:
+      - mountPath: /etc/containerd/
+        name: containerd-conf
+      - mountPath: /opt/confidential-containers/
+        name: kata-artifacts
+      - mountPath: /var/run/dbus
+        name: dbus
+      - mountPath: /run/systemd
+        name: systemd
+      - mountPath: /usr/local/bin/
+        name: local-bin
+    installerVolumes:
+      - hostPath:
+          path: /etc/containerd/
+          type: ""
+        name: containerd-conf
+      - hostPath:
+          path: /opt/confidential-containers/
+          type: DirectoryOrCreate
+        name: kata-artifacts
+      - hostPath:
+          path: /var/run/dbus
+          type: ""
+        name: dbus
+      - hostPath:
+          path: /run/systemd
+          type: ""
+        name: systemd
+      - hostPath:
+          path: /usr/local/bin/
+          type: ""
+        name: local-bin
+    installCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "install"]
+    uninstallCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "cleanup"]
+    cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
+    runtimeClassNames: ["kata", "kata-clh", "kata-qemu"]
+    postUninstall:
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:4892b726eaf15e3932dd7990e196e92bd6f964d5
+      volumeMounts:
+        - mountPath: /opt/confidential-containers/
+          name: confidential-containers-artifacts
+        - mountPath: /etc/systemd/system/
+          name: etc-systemd-system
+        - mountPath: /var/run/dbus
+          name: dbus
+        - mountPath: /run/systemd
+          name: systemd
+      volumes:
+        - hostPath:
+            path: /opt/confidential-containers/
+            type: DirectoryOrCreate
+          name: confidential-containers-artifacts
+        - hostPath:
+            path: /etc/systemd/system/
+            type: ""
+          name: etc-systemd-system
+        - hostPath:
+            path: /var/run/dbus
+            type: ""
+          name: dbus
+        - hostPath:
+            path: /run/systemd
+            type: ""
+          name: systemd
+    preInstall:
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:4892b726eaf15e3932dd7990e196e92bd6f964d5
+      volumeMounts:
+        - mountPath: /opt/confidential-containers/
+          name: confidential-containers-artifacts
+        - mountPath: /etc/systemd/system/
+          name: etc-systemd-system
+        - mountPath: /var/run/dbus
+          name: dbus
+        - mountPath: /run/systemd
+          name: systemd
+      volumes:
+        - hostPath:
+            path: /opt/confidential-containers/
+            type: DirectoryOrCreate
+          name: confidential-containers-artifacts
+        - hostPath:
+            path: /etc/systemd/system/
+            type: ""
+          name: etc-systemd-system
+        - hostPath:
+            path: /var/run/dbus
+            type: ""
+          name: dbus
+        - hostPath:
+            path: /run/systemd
+            type: ""
+          name: systemd
+    environmentVariables:
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: spec.nodeName
+      - name: "CONFIGURE_CC"
+        value: "yes"

--- a/tests/e2e/Vagrantfile
+++ b/tests/e2e/Vagrantfile
@@ -10,6 +10,7 @@
 
 # Read the runtimeClassName (e.g. kata-qemu, kata-clh, etc) from RUNTIMECLASS.
 runtimeclass = ENV['RUNTIMECLASS'] || "kata-qemu"
+runtime_payload = ENV['RUNTIME_PAYLOAD'] || ""
 guest_home_dir = '/home/vagrant'
 host_arch = `uname -m`.strip
 
@@ -42,7 +43,7 @@ Vagrant.configure("2") do |config|
       sudo apt-get -y update
       sudo apt-get -y install ansible
       cd "#{guest_home_dir}/src/confidential-containers/operator/tests/e2e"
-      ./run-local.sh -r "#{runtimeclass}"
+      ./run-local.sh -r "#{runtimeclass}" "#{"-p #{runtime_payload}" if ! runtime_payload.empty?}"
     SHELL
   end
 
@@ -54,7 +55,7 @@ Vagrant.configure("2") do |config|
       # On CentOS the docker_container module is not available on ansible-core.
       ansible-galaxy collection install community.docker
       cd "#{guest_home_dir}/src/confidential-containers/operator/tests/e2e"
-      ./run-local.sh -r "#{runtimeclass}"
+      ./run-local.sh -r "#{runtimeclass}" "#{"-p #{runtime_payload}" if ! runtime_payload.empty?}"
     SHELL
   end
 

--- a/tests/e2e/ccruntime-ssh-demo_tests.bats
+++ b/tests/e2e/ccruntime-ssh-demo_tests.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Copyright Confidential Containers Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Implement tests for the ccruntime-ssh-demo runtime.
+#
+load "${BATS_TEST_DIRNAME}/lib.sh"
+test_tag="[cc][ssh demo]"
+
+RUNTIMECLASS="${RUNTIMECLASS:-kata}"
+deployment_file="$BATS_TEST_TMPDIR/ssh-demo.yaml"
+ssh_key_file="$BATS_TEST_TMPDIR/ssh-key"
+
+setup() {
+	cat <<- EOF > "$ssh_key_file"
+	-----BEGIN OPENSSH PRIVATE KEY-----
+	b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+	QyNTUxOQAAACAfiGV2X4o+6AgjVBaY/ZR2UvZp84dVYF5bpNZGMLylQwAAAIhawtHJWsLR
+	yQAAAAtzc2gtZWQyNTUxOQAAACAfiGV2X4o+6AgjVBaY/ZR2UvZp84dVYF5bpNZGMLylQw
+	AAAEAwWYIBvBxQZgk0irFku3Lj1Xbfb8dHtVM/kkz/Uz/l2h+IZXZfij7oCCNUFpj9lHZS
+	9mnzh1VgXluk1kYwvKVDAAAAAAECAwQF
+	-----END OPENSSH PRIVATE KEY-----
+	EOF
+
+	chmod 600 "$ssh_key_file"
+
+	cat <<- EOF > "$deployment_file"
+	kind: Service
+	apiVersion: v1
+	metadata:
+	  name: ccv0-ssh
+	spec:
+	  selector:
+	    app: ccv0-ssh
+	  ports:
+	  - port: 22
+	---
+	kind: Deployment
+	apiVersion: apps/v1
+	metadata:
+	  name: ccv0-ssh
+	spec:
+	  selector:
+	    matchLabels:
+	      app: ccv0-ssh
+	  template:
+	    metadata:
+	      labels:
+	        app: ccv0-ssh
+	    spec:
+	      runtimeClassName: ${RUNTIMECLASS}
+	      containers:
+	      - name: ccv0-ssh
+	        image: docker.io/katadocker/ccv0-ssh
+	        imagePullPolicy: Always
+	EOF
+
+	# TODO: improve me.
+	kubectl delete -f "$deployment_file" || true
+	sleep 10
+}
+
+@test "$test_tag Can ssh in demo pod" {
+	kubectl apply -f "${deployment_file}"
+	# TODO: wait it be ready.
+	sleep 5
+	local pod_ip_address=$(kubectl get service ccv0-ssh \
+		-o jsonpath="{.spec.clusterIP}")
+
+	# TODO: wait it be ready.
+	sleep 30
+	ssh -i "$ssh_key_file" -o StrictHostKeyChecking=accept-new root@${pod_ip_address} \
+		grep 'agent.config_file=/etc/agent-config.toml' /proc/cmdline
+}
+
+teardown() {
+	kubectl delete -f "${deployment_file}" || true
+}


### PR DESCRIPTION
This changes the test scripts so that it is possible to install and run tests for ccruntimes other than the default.

Suppose that you want to test the ccruntime-ssh-demo from PR #101 , just do:

```
$ ./run-local.sh -r kata-qemu -p ccruntime-ssh-demo
```
Ah, and talking about the PR #101, I've converted the instructions @stevenhorsman gave on the PR into a bats test case.