### PR TITLE
Import container-engine-for-cc-payload

### DIFF
--- a/install/pre-install-payload/Makefile
+++ b/install/pre-install-payload/Makefile
@@ -1,0 +1,23 @@
+CONTAINERD_VERSION=v1.6.6.0
+
+SYSTEMD_DROP_IN_CONFIG = configs/container-engine-for-cc-override.conf.in
+
+OUTPUT_DIR = output
+
+SED = sed
+BASH = bash
+MKDIR = mkdir
+
+containerd: containerd-container-image
+
+containerd-bin:
+	$(BASH) -x containerd/build.sh
+
+containerd-systemd-drop-in: $(SYSTEMD_DROP_IN_CONFIG)
+	$(MKDIR) -p $(OUTPUT_DIR)
+	$(SED) \
+		-e "s|@CONTAINER_ENGINE@|containerd|g" \
+		$< > $(OUTPUT_DIR)/containerd-for-cc-override.conf
+
+containerd-container-image: containerd-bin containerd-systemd-drop-in
+	$(BASH) -x containerd/payload.sh

--- a/install/pre-install-payload/configs/container-engine-for-cc-override.conf.in
+++ b/install/pre-install-payload/configs/container-engine-for-cc-override.conf.in
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/opt/confidential-containers/bin/@CONTAINER_ENGINE@

--- a/install/pre-install-payload/containerd/build.sh
+++ b/install/pre-install-payload/containerd/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+script_dir=$(dirname "$(readlink -f "$0")")
+
+containerd_repo=${containerd_repo:-"https://github.com/confidential-containers/containerd"}
+containerd_version=${containerd_version:-"v1.6.6.0"}
+containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
+
+supported_arches=(
+	"linux/amd64"
+#	"linux/s390x"
+)
+
+function clone_repo() {
+	echo "Cloning the ${containerd_version} branch of the ${containerd_repo} repo"
+	git clone -b "${containerd_version}" "${containerd_repo}" "${containerd_dir}"
+}
+
+function go_to_kernel_arch() {
+	case "$1" in
+		"linux/amd64") echo "x86_64";;
+		"linux/s390x") echo "s390x";;
+		(*) echo "$1 is not supporte" && exit 1
+	esac
+		
+}
+
+function build_containerd() {
+	cc_in_containerd_dir="${containerd_dir}/confidential-containers"
+	cc_in_containerd_dockerfile="${cc_in_containerd_dir}/Dockerfile"
+	cc_in_containerd_bin_dir="${cc_in_containerd_dir}/bin"
+
+	mkdir -p "${cc_in_containerd_dir}"
+	cp ${script_dir}/build_Dockerfile "${cc_in_containerd_dockerfile}"
+
+	pushd "${containerd_dir}"
+	for arch in ${supported_arches[@]}; do
+		kernel_arch=$(go_to_kernel_arch "${arch}")
+		output_dir="${script_dir}/../output/opt/containerd-engine-for-cc-artifacts/${kernel_arch}"
+
+		echo "Building containerd for ${arch}"
+		docker buildx build \
+			--build-arg RELEASE_VER="${containerd_version}" \
+			--build-arg GO_VERSION="1.17.8" \
+			-f "${cc_in_containerd_dockerfile}" \
+			--platform="${arch}" \
+			-o "${output_dir}" \
+			.
+	done
+	popd
+}
+
+function main() {
+	clone_repo
+	build_containerd
+}
+
+main "$@"

--- a/install/pre-install-payload/containerd/build_Dockerfile
+++ b/install/pre-install-payload/containerd/build_Dockerfile
@@ -1,0 +1,49 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+ARG UBUNTU_VERSION=18.04
+ARG BASE_IMAGE=ubuntu:${UBUNTU_VERSION}
+ARG GO_VERSION
+ARG GO_IMAGE=golang:${GO_VERSION}
+FROM --platform=$BUILDPLATFORM $GO_IMAGE AS go
+FROM --platform=$BUILDPLATFORM tonistiigi/xx@sha256:425941eb25cc113009b1c651bd275e04593cea12c48311fe8ace6ceeecdcc645 AS xx
+
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS base
+COPY --from=xx / /
+SHELL ["/bin/bash", "-xec"]
+RUN	apt-get update && \
+	apt-get install -y git pkg-config
+ARG TARGETPLATFORM
+RUN xx-apt-get install -y libseccomp-dev btrfs-progs gcc
+ENV PATH=/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV CGO_ENABLED=1
+
+FROM base AS linux
+FROM ${TARGETOS} AS target
+WORKDIR /go/src/github.com/containerd/containerd
+COPY . .
+ARG TARGETPLATFORM
+ARG RELEASE_VER
+ENV VERSION=$RELEASE_VER
+RUN \
+	--mount=type=bind,from=go,source=/usr/local/go,target=/usr/local/go \
+	--mount=type=cache,target=/root/.cache/go-build \
+	--mount=type=cache,target=/go/pkg \
+	export CC=$(xx-info)-gcc && xx-go --wrap && \
+	make binaries && \
+	for f in $(find bin -executable -type f); do xx-verify $f; done
+
+FROM scratch AS confidential-containers
+COPY --from=target /go/src/github.com/containerd/containerd/bin/ /

--- a/install/pre-install-payload/containerd/payload.sh
+++ b/install/pre-install-payload/containerd/payload.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+script_dir=$(dirname "$(readlink -f "$0")")
+
+containerd_repo=${containerd_repo:-"https://github.com/confidential-containers/containerd"}
+containerd_version=${containerd_version:-"v1.6.6.0"}
+containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
+
+registry="${registry:-quay.io/confidential-containers/container-engine-for-cc-payload}"
+
+supported_arches=(
+	"linux/amd64"
+#	"linux/s390x"
+)
+
+function setup_env_for_arch() {
+	case "$1" in
+		"linux/amd64") 
+			image="docker.io/library/centos"
+			kernel_arch="x86_64"
+			;;
+		"linux/s390x")
+			image="docker.io/library/clefos"
+			kernel_arch="s390x"
+			;;
+		(*) echo "$1 is not supported" && exit 1
+	esac
+		
+}
+
+function build_containerd_payload() {
+	pushd "${script_dir}/.."
+
+	tag=$(git rev-parse HEAD)
+
+	for arch in ${supported_arches[@]}; do
+		setup_env_for_arch "${arch}"
+
+		echo "Building containerd payload image for ${arch}"
+		docker buildx build \
+			--build-arg ARCH="${kernel_arch}" \
+			-f "containerd/payload_Dockerfile" \
+			-t "${registry}:${kernel_arch}-${tag}" \
+			--platform="${arch}" \
+			--load \
+			.
+		docker push "${registry}:${kernel_arch}-${tag}"
+	done
+
+	docker manifest create \
+		${registry}:${tag} \
+		--amend ${registry}:x86_64-${tag}
+#		--amend ${registry}:s390x-${tag}
+
+	docker manifest create \
+		${registry}:latest \
+		--amend ${registry}:x86_64-${tag}
+#		--amend ${registry}:s390x-${tag}
+
+	docker manifest push ${registry}:${tag}
+	docker manifest push ${registry}:latest
+
+	popd
+}
+
+function main() {
+	build_containerd_payload
+}
+
+main "$@"

--- a/install/pre-install-payload/containerd/payload_Dockerfile
+++ b/install/pre-install-payload/containerd/payload_Dockerfile
@@ -1,0 +1,20 @@
+ARG IMAGE
+FROM ${IMAGE:-docker.io/library/centos}:7
+
+ARG ARCH
+ARG CONTAINERD_ARTIFACTS=./output/opt/containerd-engine-for-cc-artifacts/${ARCH:-x86_64}/containerd
+ARG SYSTEMD_ARTIFACTS=./output/containerd-for-cc-override.conf
+ARG CONTAINER_ENGINE_ARTIFACTS=./scripts
+ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
+
+COPY ${CONTAINERD_ARTIFACTS} ${DESTINATION}/opt/confidential-containers/bin/
+COPY ${SYSTEMD_ARTIFACTS} ${DESTINATION}/etc/systemd/system/containerd.service.d/
+COPY ${CONTAINER_ENGINE_ARTIFACTS}/* ${DESTINATION}/scripts/
+
+RUN \
+echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
+echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
+echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$(uname -m)" >> /etc/yum.repos.d/kubernetes.repo && \
+echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo && \
+yum -y install kubectl && \
+yum clean all

--- a/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
+++ b/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+die() {
+	msg="$*"
+	echo "ERROR: $msg" >&2
+	exit 1
+}
+
+function get_container_engine() {
+	local container_engine=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}' | awk -F '[:]' '{print $1}')
+	if [ "${container_engine}" != "containerd" ]; then
+		die "${container_engine} is not yet supported"
+	fi
+
+	echo "$container_engine"	
+}
+
+function set_container_engine() {
+	# Those are intentionally not set as local
+
+	container_engine=$(get_container_engine)
+}
+
+function install_artifacts() {
+	echo "Copying containerd-for-cc artifacts onto host"
+
+	local artifacts_dir="/opt/confidential-containers-pre-install-artifacts"
+
+	install -D -m 755 ${artifacts_dir}/opt/confidential-containers/bin/containerd /opt/confidential-containers/bin/containerd
+	install -D -m 644 ${artifacts_dir}/etc/systemd/system/containerd.service.d/containerd-for-cc-override.conf /etc/systemd/system/containerd.service.d/containerd-for-cc-override.conf
+}
+
+function uninstall_artifacts() {
+	echo "Removing containerd-for-cc artifacts from host"
+
+	echo "Removing the systemd drop-in file"
+	rm -f /etc/systemd/system/${container_engine}.service.d/${container_engine}-for-cc-override.conf
+	echo "Removing the systemd drop-in file's directory, if empty"
+	[ -d /etc/systemd/system/${container_engine}.service.d ] && rmdir --ignore-fail-on-non-empty /etc/systemd/system/${container_engine}.service.d
+	
+	restart_systemd_service
+
+	echo "Removing the containerd binary"
+	rm -f /opt/confidential-containers/bin/containerd
+	echo "Removing the /opt/confidential-containers directory"
+	[ -d /opt/confidential-containers/bin ] && rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers/bin
+	[ -d /opt/confidential-containers ] && rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers
+}
+
+function restart_systemd_service() {
+	systemctl daemon-reload
+	echo "Restarting ${container_engine}"
+	systemctl restart "${container_engine}"
+}
+
+label_node() {
+	case "${1}" in
+	install)
+		kubectl label node "${NODE_NAME}" cc-preinstall/done=true
+		;;
+	uninstall)
+		kubectl label node "${NODE_NAME}" cc-postuninstall/done=true
+		;;
+	*)
+		;;
+	esac
+}
+
+function print_help() {
+	echo "Help: ${0} [install/uninstall]"
+}
+
+function main() {
+	# script requires that user is root
+	local euid=$(id -u)
+	if [ ${euid} -ne 0 ]; then
+		die "This script must be run as root"
+	fi
+
+	local action=${1:-}
+	if [ -z "${action}" ]; then
+		print_help && die ""
+	fi
+
+	set_container_engine
+
+	case "${action}" in
+	install)
+		install_artifacts
+		restart_systemd_service
+		;;
+	uninstall)
+		uninstall_artifacts
+		;;
+	*)
+		print_help
+		;;
+	esac
+
+	label_node "${action}"
+
+
+	# It is assumed this script will be called as a daemonset. As a result, do
+	# not return, otherwise the daemon will restart and reexecute the script.
+	sleep infinity
+}
+
+main "$@"

--- a/install/pre-install-payload/scripts/post-uninstall.sh
+++ b/install/pre-install-payload/scripts/post-uninstall.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/opt/confidential-containers-pre-install-artifacts/scripts/container-engine-for-cc-deploy.sh uninstall

--- a/install/pre-install-payload/scripts/pre-install.sh
+++ b/install/pre-install-payload/scripts/pre-install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/opt/confidential-containers-pre-install-artifacts/scripts/container-engine-for-cc-deploy.sh install


### PR DESCRIPTION
Let's import all the files from the container-engine-for-cc-payload repo into the Operator one.

The reason for that is for simplifying development and unifying the components used by the Operator.

I've taken the decision to *not* keep the commit history as that was a very short one and not worthwhile, IMHO.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>