### PR TITLE
deploy: add CCRUNTIME_NAMESPACE env to operator

### DIFF
--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -3710,6 +3710,11 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        env:
+        - name: CCRUNTIME_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:


### PR DESCRIPTION
This should take `deploy.yaml` up-to-date with `manager.yaml` to be able to use `:latest` image.