### PR TITLE
payload: Update the SSH demo payload

### DIFF
--- a/config/samples/ccruntime-ssh-demo.yaml
+++ b/config/samples/ccruntime-ssh-demo.yaml
@@ -10,7 +10,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers-ssh-demo-03965fd37ac5eb75a72768ee36ab901865656944
+    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers-ssh-demo-v0.2.0
     installDoneLabel:
       katacontainers.io/kata-runtime: "true"
     uninstallDoneLabel:


### PR DESCRIPTION
SSH demo payload has been released based on the `CC-0.2.0` tag, let's update the image here.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>