### PR TITLE
actions: Add golangci-lint and gofmt GitHub actions

### DIFF
--- a/.github/workflows/gofmt.yaml
+++ b/.github/workflows/gofmt.yaml
@@ -1,0 +1,22 @@
+name: gofmt
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gofmt:
+    name: gofmt
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: gofmt
+        run : |
+          gofmt -s -w .
+          git diff --exit-code

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 300s

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -102,6 +102,9 @@ func (r *CcRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil && errors.IsNotFound(err) {
 		r.Log.Info("Creating cleanup Daemonset", "ds.Namespace", ds.Namespace, "ds.Name", ds.Name)
 		err = r.Client.Create(context.TODO(), ds)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Check if the CcRuntime instance is marked to be deleted, which is
@@ -789,7 +792,7 @@ func (r *CcRuntimeReconciler) makeHookDaemonset(operation DaemonOperation) *apps
 	var (
 		runPrivileged       = true
 		runAsUser     int64 = 0
-		image               = ""
+		image               = "" //nolint: ineffassign
 		dsName        string
 		volumes       []corev1.Volume
 		volumeMounts  []corev1.VolumeMount

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -326,7 +326,7 @@ func handlePostUninstall(r *CcRuntimeReconciler) (ctrl.Result, error) {
 		postUninstallDs := r.makeHookDaemonset(PostUninstallOperation)
 		// get daemonset
 		res, err := r.handlePrePostDs(postUninstallDs, map[string]string{"cc-postuninstall/done": "true"})
-		if res.Requeue == true {
+		if res.Requeue {
 			if err != nil {
 				r.Log.Info("error from handlePrePostDs")
 			}
@@ -385,7 +385,7 @@ func (r *CcRuntimeReconciler) processCcRuntimeInstallRequest() (ctrl.Result, err
 		preInstallDs := r.makeHookDaemonset(PreInstallOperation)
 		r.Log.Info("ds = ", "daemonset", preInstallDs)
 		res, err := r.handlePrePostDs(preInstallDs, map[string]string{"cc-preinstall/done": "true"})
-		if res.Requeue == true {
+		if res.Requeue {
 			r.Log.Info("requeue request from handlePrePostDs")
 			return res, err
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,7 +37,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
+var cfg *rest.Config //nolint: unused
 var k8sClient client.Client
 var testEnv *envtest.Environment
 


### PR DESCRIPTION
Let's add two simple actions related to Golang: golangci-lint and gofmt.

Those two actions are proposed to ensure we don't add new code containing neither linter issues nor non properly formatted code.