### PR TITLE
actions: Enable operator for s390x

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -54,5 +60,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/s390x
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG IMG_NAME
 ARG IMG_VERSION
 
 # Build the manager binary
-FROM ${IMG_NAME:-docker.io/bitnami/golang}:${IMG_VERSION:-1.18} as builder
+FROM ${IMG_NAME:-golang}:${IMG_VERSION:-1.18} as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
This is to enable operator image for s390x using buildx. The code changes have been tested to work: 

https://github.com/confidential-containers/operator/actions/runs/3602174182

&rightarrow; an error in the run is attributed to lack of the credential for quay.io/confidential-containers/operator.

Fixes: #131 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>