### PR TITLE
DO-NOT-MERGE | tests: Enable all the Kata Containers tests

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,12 +10,13 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 1034f9fcf947b22eea080a6f77d8e164e2369849
 - name: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-5b7009f2f9cdb39099b97a4f868b53ec9f3c383f
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-
     - op: replace
       path: /spec/config/runtimeClassNames
-      value: ["kata", "kata-clh", "kata-clh-tdx", "kata-clh-tdx-eaa-kbc", "kata-qemu", "kata-qemu-tdx", "kata-qemu-tdx-eaa-kbc", "kata-qemu-sev"]
+      value: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx", "kata-qemu-sev"]
   target:
     kind: CcRuntime

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -70,6 +70,7 @@ usage() {
 # tests for CC without specific hardware support
 run_non_tee_tests() {
 	local runtimeclass="$1"
+	local aa_kbc="${2:-"offline_fs_kbc"}"
 
 	# Results for agent_image.bats:
 	#
@@ -98,7 +99,7 @@ run_non_tee_tests() {
 	# This will be extended further to export differently based on a type of runtimeclass.
 	# At the time of writing, it is assumed that all non-tee tests use offline_fs_kbc.
 	# Discussion: https://github.com/confidential-containers/operator/pull/142#issuecomment-1359349595
-	export AA_KBC="offline_fs_kbc"
+	export AA_KBC="${aa_kbc}"
 
 	# TODO: this is a workaround for the tests that rely on `kata-runtime kata-env`
 	# to get the path to kata's configuration.toml and image files. Without this
@@ -138,9 +139,13 @@ main() {
 
 	# Run tests.
 	case $runtimeclass in
-		kata-qemu|kata-clh|kata-qemu-tdx|kata-clh-tdx)
-			echo "INFO: Running non-TEE tests for $runtimeclass"
+		kata-qemu|kata-clh|kata-clh-tdx)
+			echo "INFO: Running non-TEE tests for $runtimeclass using OfflineFS KBC"
 			run_non_tee_tests "$runtimeclass"
+			;;
+		kata-qemu-tdx)
+			echo "INFO: Running non-TEE tests for $runtimeclass using EAA KBC"
+			run_non_tee_tests "$runtimeclass" "eaa_kbc"
 			;;
 		kata-qemu-sev)
 			echo "INFO: Running kata-qemu-sev tests"

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -72,27 +72,6 @@ run_non_tee_tests() {
 	local runtimeclass="$1"
 	local aa_kbc="${2:-"offline_fs_kbc"}"
 
-	# Results for agent_image.bats:
-	#
-	# ok 1 [cc][agent][kubernetes][containerd] Test can pull an unencrypted image inside the guest
-	# ok 2 [cc][agent][kubernetes][containerd] Test can pull a unencrypted signed image from a protected registry
-	# not ok 3 [cc][agent][kubernetes][containerd] Test cannot pull an unencrypted unsigned image from a protected registry
-	# ok 4 [cc][agent][kubernetes][containerd] Test can pull an unencrypted unsigned image from an unprotected registry
-	# not ok 5 [cc][agent][kubernetes][containerd] Test unencrypted signed image with unknown signature is rejected
-
-	# Results for agent_image_encrypted.bats
-	#
-	# ok 1 [cc][agent][kubernetes][containerd] Test can pull an encrypted image inside the guest with decryption key
-	# ok 2 [cc][agent][kubernetes][containerd] Test cannot pull an encrypted image inside the guest without decryption key
-
-	local tests_passing="Test can pull an unencrypted image inside the guest"
-	tests_passing+="|Test can pull a unencrypted signed image from a protected registry"
-	tests_passing+="|Test can pull an unencrypted unsigned image from an unprotected registry"
-	tests_passing+="|Test cannot pull an encrypted image inside the guest without decryption key"
-	tests_passing+="|Test can pull an encrypted image inside the guest with decryption key"
-	tests_passing+="|Test can uninstall the operator"
-	tests_passing+="|Test can reinstall the operator"
-
 	# This will hopefully make the pods created by the tests to use
 	# the $runtimeclass.
 	export RUNTIMECLASS="$runtimeclass"
@@ -110,7 +89,7 @@ run_non_tee_tests() {
 	sed -i "s#kata-runtime kata-env#kata-runtime --config $runtime_config_file kata-env#g" \
 		../../../lib/common.bash
 
-	bats -f "$tests_passing" \
+	bats \
 		"agent_image.bats" \
 		"agent_image_encrypted.bats" \
 		"${script_dir}/operator_tests.bats"


### PR DESCRIPTION
We've been running a subset of the tests running on the Kata Containers side, which made us not realise that some features (such as measured boot) were not working with the Operator.

Let's try to enable all the tests, take a look on what breaks, and from there re-evaluate what needs to be in and what needs to be out.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>