### PR TITLE
CI: Add e2e tests for s390x

### DIFF
--- a/config/samples/ccruntime-s390x.yaml
+++ b/config/samples/ccruntime-s390x.yaml
@@ -1,0 +1,120 @@
+apiVersion: confidentialcontainers.org/v1beta1
+kind: CcRuntime
+metadata:
+  name: ccruntime-sample
+spec:
+  # Add fields here
+  runtimeName: kata
+  ccNodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+  config:
+    installType: bundle
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:kata-containers-latest
+    installDoneLabel:
+      katacontainers.io/kata-runtime: "true"
+    uninstallDoneLabel:
+      katacontainers.io/kata-runtime: "cleanup"
+    installerVolumeMounts:
+      - mountPath: /etc/containerd/
+        name: containerd-conf
+      - mountPath: /opt/confidential-containers/
+        name: kata-artifacts
+      - mountPath: /var/run/dbus
+        name: dbus
+      - mountPath: /run/systemd
+        name: systemd
+      - mountPath: /usr/local/bin/
+        name: local-bin
+    installerVolumes:
+      - hostPath:
+          path: /etc/containerd/
+          type: ""
+        name: containerd-conf
+      - hostPath:
+          path: /opt/confidential-containers/
+          type: DirectoryOrCreate
+        name: kata-artifacts
+      - hostPath:
+          path: /var/run/dbus
+          type: ""
+        name: dbus
+      - hostPath:
+          path: /run/systemd
+          type: ""
+        name: systemd
+      - hostPath:
+          path: /usr/local/bin/
+          type: ""
+        name: local-bin
+    installCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "install"]
+    uninstallCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "cleanup"]
+    cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
+    # Uncomment and add the required RuntimeClassNames to be created
+    # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
+    runtimeClassNames: 
+      ["kata", "kata-qemu"]
+    postUninstall:
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:s390x-f0c7fc73c97e0a7222eb8b39a13b3cca16a9a5c1
+      volumeMounts:
+        - mountPath: /opt/confidential-containers/
+          name: confidential-containers-artifacts
+        - mountPath: /etc/systemd/system/
+          name: etc-systemd-system
+        - mountPath: /var/run/dbus
+          name: dbus
+        - mountPath: /run/systemd
+          name: systemd
+      volumes:
+        - hostPath:
+            path: /opt/confidential-containers/
+            type: DirectoryOrCreate
+          name: confidential-containers-artifacts
+        - hostPath:
+            path: /etc/systemd/system/
+            type: ""
+          name: etc-systemd-system
+        - hostPath:
+            path: /var/run/dbus
+            type: ""
+          name: dbus
+        - hostPath:
+            path: /run/systemd
+            type: ""
+          name: systemd
+    preInstall:
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:s390x-f0c7fc73c97e0a7222eb8b39a13b3cca16a9a5c1
+      volumeMounts:
+        - mountPath: /opt/confidential-containers/
+          name: confidential-containers-artifacts
+        - mountPath: /etc/systemd/system/
+          name: etc-systemd-system
+        - mountPath: /var/run/dbus
+          name: dbus
+        - mountPath: /run/systemd
+          name: systemd
+      volumes:
+        - hostPath:
+            path: /opt/confidential-containers/
+            type: DirectoryOrCreate
+          name: confidential-containers-artifacts
+        - hostPath:
+            path: /etc/systemd/system/
+            type: ""
+          name: etc-systemd-system
+        - hostPath:
+            path: /var/run/dbus
+            type: ""
+          name: dbus
+        - hostPath:
+            path: /run/systemd
+            type: ""
+          name: systemd
+    environmentVariables:
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: spec.nodeName
+      - name: "CONFIGURE_CC"
+        value: "yes"

--- a/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
+++ b/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
@@ -94,6 +94,13 @@ function main() {
 		restart_systemd_service
 		;;
 	uninstall)
+		# Adjustment for s390x (clefos:7)
+		# It is identified that a node is not labeled during post-uninstall,
+		# if the function is called after container engine is restarted by systemctl.
+		# This results in having the uninstallation not triggered.
+		if [ "$(uname -m)" = "s390x" ];
+			label_node "${action}"
+		fi
 		uninstall_artifacts
 		;;
 	*)

--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -25,3 +25,4 @@ test_pkgs:
     - jq
   centos:
     - jq
+target_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"

--- a/tests/e2e/ansible/install_build_deps.yml
+++ b/tests/e2e/ansible/install_build_deps.yml
@@ -16,7 +16,7 @@
       - name: Download and extract Go tarball
         unarchive:
           # TODO: use facts
-          src: https://go.dev/dl/go{{ go_version }}.linux-amd64.tar.gz
+          src: https://go.dev/dl/go{{ go_version }}.linux-{{ target_arch }}.tar.gz
           creates: /usr/local/go
           dest: /usr/local
           remote_src: yes
@@ -28,7 +28,7 @@
     - name: Install the operator-sdk
       get_url:
         # TODO: use facts
-        url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk_linux_amd64
+        url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk_linux_{{ target_arch }}
         dest: /usr/local/bin/operator-sdk
         mode: '+x'
     - import_tasks: "install_docker.yml"

--- a/tests/e2e/ansible/install_docker.yml
+++ b/tests/e2e/ansible/install_docker.yml
@@ -29,7 +29,7 @@
         state: present
     - name: Add docker repo
       apt_repository:
-        repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable"
+        repo: "deb [arch={{ target_arch }} signed-by=/etc/apt/trusted.gpg.d/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable"
         filename: docker
         update_cache: yes
         state: present

--- a/tests/e2e/ansible/install_kubeadm.yml
+++ b/tests/e2e/ansible/install_kubeadm.yml
@@ -32,18 +32,18 @@
     - name: Install CNI plugins
       unarchive:
         # TODO: use facts
-        src: "https://github.com/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-linux-amd64-{{ cni_version }}.tgz"
+        src: "https://github.com/containernetworking/plugins/releases/download/{{ cni_version }}/cni-plugins-linux-{{ target_arch  }}-{{ cni_version }}.tgz"
         dest: "{{ cni_home }}/bin"
         remote_src: yes
     - name: Install crictl
       unarchive:
-        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ k8s_version }}/crictl-{{ k8s_version }}-linux-amd64.tar.gz"
+        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/{{ k8s_version }}/crictl-{{ k8s_version }}-linux-{{ target_arch  }}.tar.gz"
         creates: /usr/local/bin/crictl
         dest: /usr/local/bin
         remote_src: yes
     - name: Install kube binaries
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/{{ k8s_version }}/bin/linux/amd64/{{ item }}
+        url: https://storage.googleapis.com/kubernetes-release/release/{{ k8s_version }}/bin/linux/{{ target_arch  }}/{{ item }}
         dest: /usr/local/bin
         mode: '+x'
       with_items:

--- a/tests/e2e/ansible/install_test_deps.yml
+++ b/tests/e2e/ansible/install_test_deps.yml
@@ -33,7 +33,7 @@
       - name: Download and extract Go tarball
         unarchive:
           # TODO: use facts
-          src: https://go.dev/dl/go{{ go_version }}.linux-amd64.tar.gz
+          src: https://go.dev/dl/go{{ go_version }}.linux-{{ target_arch }}.tar.gz
           creates: /usr/local/go
           dest: /usr/local
           remote_src: yes

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -95,6 +95,10 @@ run_non_tee_tests() {
 	# This will hopefully make the pods created by the tests to use
 	# the $runtimeclass.
 	export RUNTIMECLASS="$runtimeclass"
+	# This will be extended further to export differently based on a type of runtimeclass.
+	# At the time of writing, it is assumed that all non-tee tests use offline_fs_kbc.
+	# Discussion: https://github.com/confidential-containers/operator/pull/142#issuecomment-1359349595
+	export AA_KBC="offline_fs_kbc"
 
 	# TODO: this is a workaround for the tests that rely on `kata-runtime kata-env`
 	# to get the path to kata's configuration.toml and image files. Without this


### PR DESCRIPTION
This is to add e2e tests for s390x based on the same base as x86_64.

A CI job is configured at http://jenkins.katacontainers.io/job/confidential-containers-operator-main-ubuntu-20.04-s390x-containerd_kata-qemu-PR/ and appears as `cc-operator-e2e-ubuntu-20.04-s390x-containerd_kata-qemu` in the merge status list below. 

Once the PR is merged, the CI job will be triggered for every PR.

Fixes: #138

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>