### PR TITLE
Add ENVs for enclave-cc specific config parsing in runtime deployment.

### DIFF
--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -120,3 +120,7 @@ spec:
             fieldPath: spec.nodeName
       - name: "CONFIGURE_CC"
         value: "yes"
+      - name: "DECRYPT_CONFIG"
+        value: "ewogICAgImtleV9wcm92aWRlciI6ICJwcm92aWRlcjphdHRlc3RhdGlvbi1hZ2VudDplYWFfa2JjOjoxNzIuMTcuMy4xMTM6MTIzNCIsCiAgICAic2VjdXJpdHlfdmFsaWRhdGUiOiB0cnVlCn0K"
+      - name: "OCICRYPT_CONFIG"
+        value: "ewogICAgImtleS1wcm92aWRlcnMiOiB7CiAgICAgICAgImF0dGVzdGF0aW9uLWFnZW50IjogewogICAgICAgICAgICAibmF0aXZlIjogImF0dGVzdGF0aW9uLWFnZW50IgogICAgICAgIH0KICAgIH0KfQo="


### PR DESCRIPTION
enclave-cc repo related PR is [here](https://github.com/confidential-containers/enclave-cc/pull/83).
Major ideas:
1. Define ENVs in ccruntime.yaml for configuration.(base64 encoded string)
2. In enclave-cc runtime deployment, deploy script parses ENVs, generates related configuration files and installs to payload specific path.
3. The path has already been mounted to occlum instance when "occlum build".

Signed-off-by: Jie Ren <jie.ren@intel.com>