### PR TITLE
config: Update preInstall payload

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
-  newTag: 1034f9fcf947b22eea080a6f77d8e164e2369849
+  newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-latest

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-latest
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
-  newTag: s390x-f0c7fc73c97e0a7222eb8b39a13b3cca16a9a5c1
+  newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/ssh-demo/kustomization.yaml
+++ b/config/samples/ccruntime/ssh-demo/kustomization.yaml
@@ -10,7 +10,7 @@ images:
 - name: quay.io/confidential-containers/runtime-payload
   newTag: kata-containers-ssh-demo-v0.2.0
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
-  newTag: 1034f9fcf947b22eea080a6f77d8e164e2369849
+  newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -57,7 +57,7 @@ spec:
     cleanupCmd: ["/opt/enclave-cc-artifacts/scripts/enclave-cc-deploy.sh", "reset"]
     runtimeClassNames: ["enclave-cc"]
     postUninstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:1034f9fcf947b22eea080a6f77d8e164e2369849
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:1def978fdf6b0cb2383d43970c3dc484df3cad54
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
@@ -85,7 +85,7 @@ spec:
             type: ""
           name: systemd
     preInstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:1034f9fcf947b22eea080a6f77d8e164e2369849
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:1def978fdf6b0cb2383d43970c3dc484df3cad54
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts


### PR DESCRIPTION
Let's point to the payload generated from the 1def978fdf commit, which includes the bump to containerd v1.6.8.1, and has a multi-arch image.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>