### PR TITLE
tests: set OPERATOR variable to true

### DIFF
--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -15,6 +15,7 @@ project_dir="$(readlink -f ${script_dir}/../..)"
 export GOPATH="$(mktemp -d)"
 tests_repo_dir="$GOPATH/src/github.com/kata-containers/tests"
 export CI=true
+export OPERATOR=true
 
 # TODO: Debug should be enabled in order for some tests to enable the console
 # debug and search for patterns on agent logs. Probably console debug should


### PR DESCRIPTION
add OPERATOR set to true for local test running
This is needed for certain tests (sev.bats) to distinguish between the general CI and the operator CI and to set the runtime class accordingly

Signed-Off-By: Ryan Savino <ryan.savino@amd.com>