### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/tests/e2e/ansible/templates/kubeadm.conf.j2
+++ b/tests/e2e/ansible/templates/kubeadm.conf.j2
@@ -20,7 +20,7 @@ apiServer:
   extraArgs:
     feature-gates: PodOverhead=true
   timeoutForControlPlane: 4m0s
-imageRepository: k8s.gcr.io
+imageRepository: registry.k8s.io
 scheduler:
   extraArgs:
     feature-gates: PodOverhead=true


### PR DESCRIPTION
This fix is a part of an umbrella issue https://github.com/kubernetes/k8s.io/issues/4780