### PR TITLE
config: Update to the latest CI payloads

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-b91337afef54d94e7f6458a0d1548e921dab6ea0-x86_64
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -8,8 +8,8 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-b91337afef54d94e7f6458a0d1548e921dab6ea0-s390x
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
 

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-v0.3.1
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-latest
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload
-  newTag: enclave-cc-SIM-v0.3.1
+- name: quay.io/confidential-containers/runtime-payload-ci
+  newTag: enclave-cc-SIM-latest


### PR DESCRIPTION
Let's bump to the latest CI payloads and make sure those are and will continue to be passing the CI till we release the Operator at some point soon.