### PR TITLE
tests: Specify unix:// prefix on CRI socket path

### DIFF
--- a/tests/e2e/cluster/down.sh
+++ b/tests/e2e/cluster/down.sh
@@ -15,7 +15,7 @@ script_dir="$(dirname "$(readlink -f "$0")")"
 #
 reset_kubeadm() {
 	# TODO: make it configurable.
-	local cri_runtime_socket="/run/containerd/containerd.sock"
+	local cri_runtime_socket="unix:///run/containerd/containerd.sock"
 
 	kubeadm reset -f --cri-socket="${cri_runtime_socket}"
 


### PR DESCRIPTION
The `kubeadm reset` command currently prints a lot of spam on the console:

> 17:43:55 W0302 16:43:55.496646  774291 cleanupnode.go:93] [reset] Failed to remove containers: [failed to stop running pod I0302: output: I0302 16:43:53.203139  774335 util_unix.go:104] "Using this format as endpoint is deprecated, please consider using full url format." deprecatedFormat="/run/containerd/containerd.sock" fullURLFormat="unix:///run/containerd/containerd.sock"

This then followed by a lot of followup spam.  I'm not quite sure what is happening, but let's try to get rid of the spam by getting rid of the initial warning.