### PR TITLE
config: Update deps to v0.4.0 release

### DIFF
--- a/config/release/kustomization.yaml
+++ b/config/release/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 # newTag points to the latest release image and must be updated before tagging a new release
 images:
 - name: quay.io/confidential-containers/operator
-  newTag: v0.2.0
+  newTag: v0.4.0

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-latest
+  newName: quay.io/confidential-containers/runtime-payload
+  newTag: kata-containers-129e43d1ea5cca528b7b97234b7561219208a244-x86_64
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -8,8 +8,8 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-latest
+  newName: quay.io/confidential-containers/runtime-payload
+  newTag: kata-containers-129e43d1ea5cca528b7b97234b7561219208a244-s390x
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
 

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-latest
+    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-v0.4.0
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-latest
+- name: quay.io/confidential-containers/runtime-payload
+  newTag: enclave-cc-SIM-v0.4.0


### PR DESCRIPTION
As part of v0.4.0 release we're bringing in the following images:
* kata-containers-129e43d1ea5cca528b7b97234b7561219208a244-x86_64
* kata-containers-129e43d1ea5cca528b7b97234b7561219208a244-s390x
* enclave-cc-HW-v0.4.0
* enclave-cc-SIM-v0.4.0