### PR TITLE
config: Update payloads to the latest CI image

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,10 +8,10 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
-  newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
+  newTag: latest
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-6abfb9deadc03154f91896e78ea024e55928c9f4-x86_64
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -8,10 +8,10 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
-  newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
+  newTag: latest
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-6abfb9deadc03154f91896e78ea024e55928c9f4-x86_64
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -8,10 +8,10 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-6abfb9deadc03154f91896e78ea024e55928c9f4-s390x
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
-  newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
+  newTag: latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -4,14 +4,7 @@ kind: Kustomization
 nameSuffix: -s390x
 
 resources:
-- ../base
-
-images:
-- name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-latest
-- name: quay.io/confidential-containers/container-engine-for-cc-payload
-  newTag: latest
+- ../default
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-v0.5.0
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-latest
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload
-  newTag: enclave-cc-SIM-v0.5.0
+- name: quay.io/confidential-containers/runtime-payload-ci
+  newTag: enclave-cc-SIM-latest


### PR DESCRIPTION
- Now 0.4 release has been tagged, update the config to point to the latest runtime-payloads for 'CI' testing purposes

Fixes: #168