### PR TITLE
pre-install: Install sev cert on host

### DIFF
--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -52,7 +52,7 @@ spec:
     cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
     # Uncomment and add the required RuntimeClassNames to be created
     # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
-    runtimeClassNames: 
+    runtimeClassNames:
       [""]
     postUninstall:
       image: quay.io/confidential-containers/container-engine-for-cc-payload
@@ -87,6 +87,8 @@ spec:
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
+        - mountPath: /opt/sev/
+          name: sev-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
         - mountPath: /var/run/dbus
@@ -98,6 +100,10 @@ spec:
             path: /opt/confidential-containers/
             type: DirectoryOrCreate
           name: confidential-containers-artifacts
+        - hostPath:
+            path: /opt/sev/
+            type: DirectoryOrCreate
+          name: sev-artifacts
         - hostPath:
             path: /etc/systemd/system/
             type: ""

--- a/install/pre-install-payload/containerd/Dockerfile
+++ b/install/pre-install-payload/containerd/Dockerfile
@@ -1,3 +1,11 @@
+FROM rust:1.67 as build_sevctl
+WORKDIR /usr/src/
+RUN apt update && apt install -y pkg-config libssl-dev asciidoctor musl-tools
+RUN git clone https://github.com/virtee/sevctl
+RUN rustup target add x86_64-unknown-linux-musl
+WORKDIR /usr/src/sevctl
+RUN cargo build --release --target x86_64-unknown-linux-musl
+
 ARG IMAGE
 FROM ${IMAGE:-docker.io/library/centos}:7
 
@@ -10,14 +18,15 @@ ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
 COPY ${CONTAINERD_ARTIFACTS} ${DESTINATION}/opt/confidential-containers/
 COPY ${SYSTEMD_ARTIFACTS} ${DESTINATION}/etc/systemd/system/containerd.service.d/
 COPY ${CONTAINER_ENGINE_ARTIFACTS}/* ${DESTINATION}/scripts/
+COPY --from=build_sevctl /usr/src/sevctl/target/x86_64-unknown-linux-musl/release/sevctl /usr/local/sbin/sevctl
 
 RUN \
-curl -fOL --progress-bar https://github.com/confidential-containers/containerd/releases/download/v${VERSION}/containerd-${VERSION}-linux-${ARCH}.tar.gz && \
-tar xvzpf containerd-${VERSION}-linux-${ARCH}.tar.gz -C ${DESTINATION}/opt/confidential-containers && \
-rm -f containerd-${VERSION}-linux-${ARCH}.tar.gz && \
-echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$(uname -m)" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo && \
-yum -y install kubectl && \
-yum clean all
+    curl -fOL --progress-bar https://github.com/confidential-containers/containerd/releases/download/v${VERSION}/containerd-${VERSION}-linux-${ARCH}.tar.gz && \
+    tar xvzpf containerd-${VERSION}-linux-${ARCH}.tar.gz -C ${DESTINATION}/opt/confidential-containers && \
+    rm -f containerd-${VERSION}-linux-${ARCH}.tar.gz && \
+    echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
+    echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
+    echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$(uname -m)" >> /etc/yum.repos.d/kubernetes.repo && \
+    echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo && \
+    yum -y install kubectl && \
+    yum clean all


### PR DESCRIPTION
Fixes: https://github.com/confidential-containers/operator/issues/81

---

## Testing

Prerequiste:
- A working kuberentes cluster with a SEV machine acting as a worker node.

Build the manager:

```bash
export IMG=quay.io/<username>/cc-operator
make docker-build
make docker-push
```

Build the payload image the one that has `sevctl` installed and will be run as a part of `pre-install` daemonset:

```bash
pushd install/pre-install-payload
export registry=quay.io/<username>/container-engine-for-cc-payload
make
popd
```

Extract the image tag:

```bash
tag=$(docker images --filter=reference="${registry}" --format "{{.Tag}}" | grep x86 | head -1)
echo "${registry}:${tag}"
```

Modify the kustomization with the above image name:

```diff
$ git diff config/samples/ccruntime/default/kustomization.yaml
diff --git config/samples/ccruntime/default/kustomization.yaml config/samples/ccruntime/default/kustomization.yaml
index c64c512..b422d15 100644
--- config/samples/ccruntime/default/kustomization.yaml
+++ config/samples/ccruntime/default/kustomization.yaml
@@ -20,3 +20,9 @@ patches:
       value: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx", "kata-qemu-sev"]
   target:
     kind: CcRuntime
+- patch: |-
+    - op: replace
+      path: /spec/config/preInstall/image
+      value: <output of the above echo command>
+  target:
+    kind: CcRuntime
```

Now deploy the payload:

```bash
make install && make deploy
kubectl create -k config/samples/ccruntime/default
```

Once deployed, verify on the host, if there is a certificate file at: `/opt/sev/cert_chain.cert`.

Uninstall & Cleanup:

```bash
make uninstall && make undeploy
```