### PR TITLE
workflow: Add push field to action

### DIFF
--- a/.github/workflows/docker-publish-latest-on-merge.yml
+++ b/.github/workflows/docker-publish-latest-on-merge.yml
@@ -64,6 +64,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          push: true
           platforms: linux/amd64,linux/s390x
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add `push: true` to the build and push action,
so it actually pushes the container image!

Fixes: #173