### PR TITLE
workflow: build and push container-engine-for-cc-payload image on merge

### DIFF
--- a/.github/workflows/pre-install-image-publish-on-merge.yml
+++ b/.github/workflows/pre-install-image-publish-on-merge.yml
@@ -1,0 +1,44 @@
+name: Publish container-engine-for-cc-payload latest image on push to main
+
+# When an push to `main` happens and changed the files under install/pre-install-payload/,
+# build and push the multi-arch image to latest
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - install/pre-install-payload/**
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  buid:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_ID }}
+          password: ${{ secrets.QUAY_SECRET }}
+
+      - name: Build and push to registry
+        run: |
+          cd install/pre-install-payload
+          make containerd


### PR DESCRIPTION
The container-engine-for-cc-payload will be built only and only if install/pre-install-payload/** files changed, then pushed to quay.io.

Fixes #175
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>