### PR TITLE
tests/e2e: test changes to the pre-install-payload image

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,12 +25,20 @@ jobs:
         with:
           driver-opts: network=host
 
-      - name: Build and push to local registry
+      - name: Build and push the operator image to local registry
         run: |
           make docker-build
           make docker-push
         env:
           IMG: localhost:5000/cc-operator:latest
+
+      - name: Build and push the pre-install to local registry
+        run: |
+          pushd install/pre-install-payload
+          make containerd registry="${REGISTRY}" extra_docker_manifest_flags="--insecure"
+          popd
+        env:
+          REGISTRY: localhost:5000/container-engine-for-cc-payload
 
       - name: Build custom kind node image
         uses: docker/build-push-action@v4
@@ -57,7 +65,9 @@ jobs:
 
       - name: Install enclave-cc sim
         run: |
-          kubectl apply -k config/samples/enclave-cc/sim
+          cd config/samples/enclave-cc/sim
+          kustomize edit set image quay.io/confidential-containers/container-engine-for-cc-payload=localhost:5000/container-engine-for-cc-payload:latest
+          kubectl apply -k . 
           sleep 1
           kubectl wait --for=jsonpath='{.status.runtimeClass}'=enclave-cc ccruntime/ccruntime-enclave-cc-sgx-mode-sim --timeout=90s
 

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -47,7 +47,7 @@ spec:
     - name: "enclave-cc"
       snapshotter: "overlayfs"
     postUninstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:98a790e8abdcc06c4b629b290ebaa217bf82e305
+      image: quay.io/confidential-containers/container-engine-for-cc-payload
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
@@ -75,7 +75,7 @@ spec:
             type: ""
           name: systemd
     preInstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:98a790e8abdcc06c4b629b290ebaa217bf82e305
+      image: quay.io/confidential-containers/container-engine-for-cc-payload
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts

--- a/config/samples/enclave-cc/base/kustomizeconfig.yaml
+++ b/config/samples/enclave-cc/base/kustomizeconfig.yaml
@@ -1,3 +1,7 @@
 images:
 - path: spec/config/payloadImage
   kind: CcRuntime
+- path: spec/config/preInstall/image
+  kind: CcRuntime
+- path: spec/config/postUninstall/image
+  kind: CcRuntime

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
 - ../base
 
 nameSuffix: -sgx-mode-hw
+
+- name: quay.io/confidential-containers/container-engine-for-cc-payload
+  newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -6,3 +6,5 @@ nameSuffix: -sgx-mode-sim
 images:
 - name: quay.io/confidential-containers/runtime-payload-ci
   newTag: enclave-cc-SIM-sample-kbc-latest
+- name: quay.io/confidential-containers/container-engine-for-cc-payload
+  newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305

--- a/install/pre-install-payload/containerd/payload.sh
+++ b/install/pre-install-payload/containerd/payload.sh
@@ -9,6 +9,7 @@ script_dir=$(dirname "$(readlink -f "$0")")
 containerd_repo=${containerd_repo:-"https://github.com/confidential-containers/containerd"}
 containerd_version=${containerd_version:-"v1.6.6.0"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
+extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
 
 registry="${registry:-quay.io/confidential-containers/container-engine-for-cc-payload}"
 
@@ -52,18 +53,18 @@ function build_containerd_payload() {
 		docker push "${registry}:${kernel_arch}-${tag}"
 	done
 
-	docker manifest create \
+	docker manifest create ${extra_docker_manifest_flags} \
 		${registry}:${tag} \
 		--amend ${registry}:x86_64-${tag} \
 		--amend ${registry}:s390x-${tag}
 
-	docker manifest create \
+	docker manifest create ${extra_docker_manifest_flags} \
 		${registry}:latest \
 		--amend ${registry}:x86_64-${tag} \
 		--amend ${registry}:s390x-${tag}
 
-	docker manifest push ${registry}:${tag}
-	docker manifest push ${registry}:latest
+	docker manifest push ${extra_docker_manifest_flags} ${registry}:${tag}
+	docker manifest push ${extra_docker_manifest_flags} ${registry}:latest
 
 	popd
 }

--- a/install/pre-install-payload/containerd/payload.sh
+++ b/install/pre-install-payload/containerd/payload.sh
@@ -33,6 +33,18 @@ function setup_env_for_arch() {
 		
 }
 
+function purge_previous_manifests() {
+	manifest=${1}
+	
+	# We need to sanitise the name by:
+	# * Replacing:
+	#   * '/' by '_'
+	#   * ':' by '-'
+	
+	sanitised_manifest="$(echo ${manifest} | sed 's|/|_|g' | sed 's|:|-|g')"
+	rm -rf ${HOME}/.docker/manifests/${sanitised_manifest}
+}
+
 function build_containerd_payload() {
 	pushd "${script_dir}/.."
 
@@ -52,6 +64,9 @@ function build_containerd_payload() {
 			.
 		docker push "${registry}:${kernel_arch}-${tag}"
 	done
+
+	purge_previous_manifests ${registry}:${tag}
+	purge_previous_manifests ${registry}:latest
 
 	docker manifest create ${extra_docker_manifest_flags} \
 		${registry}:${tag} \

--- a/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
+++ b/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
@@ -50,9 +50,8 @@ function uninstall_artifacts() {
 
 	echo "Removing the containerd binary"
 	rm -f /opt/confidential-containers/bin/containerd
-	echo "Removing the /opt/confidential-containers directory"
+	echo "Removing the /opt/confidential-containers/bin directory"
 	[ -d /opt/confidential-containers/bin ] && rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers/bin
-	[ -d /opt/confidential-containers ] && rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers
 }
 
 function restart_systemd_service() {

--- a/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
+++ b/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
@@ -44,14 +44,18 @@ function uninstall_artifacts() {
 	echo "Removing the systemd drop-in file"
 	rm -f /etc/systemd/system/${container_engine}.service.d/${container_engine}-for-cc-override.conf
 	echo "Removing the systemd drop-in file's directory, if empty"
-	[ -d /etc/systemd/system/${container_engine}.service.d ] && rmdir --ignore-fail-on-non-empty /etc/systemd/system/${container_engine}.service.d
+	if [ -d /etc/systemd/system/${container_engine}.service.d ]; then
+		rmdir --ignore-fail-on-non-empty /etc/systemd/system/${container_engine}.service.d
+	fi
 	
 	restart_systemd_service
 
 	echo "Removing the containerd binary"
 	rm -f /opt/confidential-containers/bin/containerd
 	echo "Removing the /opt/confidential-containers/bin directory"
-	[ -d /opt/confidential-containers/bin ] && rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers/bin
+	if [ -d /opt/confidential-containers/bin ]; then
+		rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers/bin
+	fi
 }
 
 function restart_systemd_service() {

--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -5,6 +5,7 @@ build_pkgs:
   ubuntu:
     - make
     - gcc
+    - qemu-user-static
   centos:
     - make
     - gcc

--- a/tests/e2e/ansible/install_build_deps.yml
+++ b/tests/e2e/ansible/install_build_deps.yml
@@ -32,6 +32,19 @@
         dest: /usr/local/bin/operator-sdk
         mode: '+x'
     - import_tasks: "install_docker.yml"
+      # Docker buildx relies on qemu-user-static to multi-arch builds, but
+      # qemu-user-static is not packaged for CentOS. Let's get it installed via
+      # https://github.com/multiarch/qemu-user-static
+    - name: Handle qemu-user-static installation on CentOS.
+      block:
+        - name: Check qemu-user-static is installed
+          shell: docker run --rm -t s390x/ubuntu:22.04 uname -m
+          register: qemu_user_static_exist
+          ignore_errors: yes
+        - name: Install qemu-user-static
+          shell: docker run --rm --privileged multiarch/qemu-user-static:7.2.0-1 --reset -p yes
+          when: qemu_user_static_exist.rc != 0
+      when: ansible_distribution == "CentOS"
     # Undo the installation.
     #
     - name: Uninstall build dependencies

--- a/tests/e2e/ansible/install_test_deps.yml
+++ b/tests/e2e/ansible/install_test_deps.yml
@@ -29,6 +29,17 @@
                 path: bats-core
                 state: absent
           when: bats_exist.rc != 0
+    - name: Check kustomize is installed
+      shell: command -v kustomize >/dev/null 2>&1
+      register: kustomize_exist
+      ignore_errors: yes
+    - name: Install kustomize
+      shell: |
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        cp -f ./kustomize /usr/local/bin
+      args:
+        creates: /usr/local/bin/kustomize
+      when: kustomize_exist.rc != 0
     - block:
       - name: Download and extract Go tarball
         unarchive:
@@ -56,3 +67,4 @@
             - /usr/local/bin/go
             - /usr/local/go
             - /usr/local/bin/bats
+            - /usr/local/bin/kustomize


### PR DESCRIPTION
Currently changes on install/pre-install-payload directory aren't tested because the scripts aren't re-building the pre-install-payload image, and with this change the image will always be built and used.

Fixes #177 