### PR TITLE
Update payloads to using the ubuntu base image

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,9 +31,16 @@ jobs:
         env:
           IMG: localhost:5000/cc-operator:latest
 
+      - name: Build custom kind node image
+        uses: docker/build-push-action@v4
+        with:
+          context: tests/e2e/kind
+          load: true
+          tags: kindest/node:v1.26.0-coco
+
       - name: Setup kind cluster
         run: |
-          kind create cluster --image "kindest/node:v1.26.0" -n coco-sgx --config tests/e2e/enclave-cc-kind-config.yaml --wait 120s
+          kind create cluster --image "kindest/node:v1.26.0-coco" -n coco-sgx --config tests/e2e/enclave-cc-kind-config.yaml --wait 120s
           kubectl label node coco-sgx-worker node-role.kubernetes.io/worker=
 
       - name: Deploy operator from the local registry

--- a/.github/workflows/enclave-cc-cicd.yaml
+++ b/.github/workflows/enclave-cc-cicd.yaml
@@ -30,9 +30,16 @@ jobs:
         env:
           IMG: localhost:5000/cc-operator:latest
 
+      - name: Build custom kind node image
+        uses: docker/build-push-action@v4
+        with:
+          context: tests/e2e/kind
+          load: true
+          tags: kindest/node:v1.26.0-coco
+
       - name: Setup kind cluster
         run: |
-          kind create cluster --image "kindest/node:v1.26.0" -n coco-sgx --config tests/e2e/enclave-cc-kind-config.yaml --wait 120s
+          kind create cluster --image "kindest/node:v1.26.0-coco" -n coco-sgx --config tests/e2e/enclave-cc-kind-config.yaml --wait 120s
           kubectl label node coco-sgx-worker node-role.kubernetes.io/worker=
 
       - name: Deploy operator from the local registry

--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -55,11 +55,11 @@ metadata:
                   "name": "kata-artifacts"
                 },
                 {
-                  "mountPath": "/var/run/dbus",
+                  "mountPath": "/var/run/dbus/system_bus_socket",
                   "name": "dbus"
                 },
                 {
-                  "mountPath": "/run/systemd",
+                  "mountPath": "/run/systemd/system",
                   "name": "systemd"
                 },
                 {
@@ -84,14 +84,14 @@ metadata:
                 },
                 {
                   "hostPath": {
-                    "path": "/var/run/dbus",
+                    "path": "/var/run/dbus/system_bus_socket",
                     "type": ""
                   },
                   "name": "dbus"
                 },
                 {
                   "hostPath": {
-                    "path": "/run/systemd",
+                    "path": "/run/systemd/system",
                     "type": ""
                   },
                   "name": "systemd"
@@ -117,11 +117,11 @@ metadata:
                     "name": "etc-systemd-system"
                   },
                   {
-                    "mountPath": "/var/run/dbus",
+                    "mountPath": "/var/run/dbus/system_bus_socket",
                     "name": "dbus"
                   },
                   {
-                    "mountPath": "/run/systemd",
+                    "mountPath": "/run/systemd/system",
                     "name": "systemd"
                   }
                 ],
@@ -142,14 +142,14 @@ metadata:
                   },
                   {
                     "hostPath": {
-                      "path": "/var/run/dbus",
+                      "path": "/var/run/dbus/system_bus_socket",
                       "type": ""
                     },
                     "name": "dbus"
                   },
                   {
                     "hostPath": {
-                      "path": "/run/systemd",
+                      "path": "/run/systemd/system",
                       "type": ""
                     },
                     "name": "systemd"
@@ -168,11 +168,11 @@ metadata:
                     "name": "etc-systemd-system"
                   },
                   {
-                    "mountPath": "/var/run/dbus",
+                    "mountPath": "/var/run/dbus/system_bus_socket",
                     "name": "dbus"
                   },
                   {
-                    "mountPath": "/run/systemd",
+                    "mountPath": "/run/systemd/system",
                     "name": "systemd"
                   }
                 ],
@@ -193,14 +193,14 @@ metadata:
                   },
                   {
                     "hostPath": {
-                      "path": "/var/run/dbus",
+                      "path": "/var/run/dbus/system_bus_socket",
                       "type": ""
                     },
                     "name": "dbus"
                   },
                   {
                     "hostPath": {
-                      "path": "/run/systemd",
+                      "path": "/run/systemd/system",
                       "type": ""
                     },
                     "name": "systemd"

--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -20,9 +20,9 @@ spec:
         name: containerd-conf
       - mountPath: /opt/confidential-containers/
         name: kata-artifacts
-      - mountPath: /var/run/dbus
+      - mountPath: /var/run/dbus/system_bus_socket
         name: dbus
-      - mountPath: /run/systemd
+      - mountPath: /run/systemd/system
         name: systemd
       - mountPath: /usr/local/bin/
         name: local-bin
@@ -36,11 +36,11 @@ spec:
           type: DirectoryOrCreate
         name: kata-artifacts
       - hostPath:
-          path: /var/run/dbus
+          path: /var/run/dbus/system_bus_socket
           type: ""
         name: dbus
       - hostPath:
-          path: /run/systemd
+          path: /run/systemd/system
           type: ""
         name: systemd
       - hostPath:

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-129e43d1ea5cca528b7b97234b7561219208a244-x86_64
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-121892ec61cb7d50c662133bb6fbf25b50ab676e-x86_64
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -8,8 +8,8 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-129e43d1ea5cca528b7b97234b7561219208a244-s390x
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-121892ec61cb7d50c662133bb6fbf25b50ab676e-s390x
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-v0.4.0
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-4370700439f5524a60cf7a31c7c4f92bbe4dd655
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:
@@ -21,9 +21,9 @@ spec:
         name: enclave-cc-conf
       - mountPath: /opt/confidential-containers/
         name: enclave-cc-artifacts
-      - mountPath: /var/run/dbus
+      - mountPath: /var/run/dbus/system_bus_socket
         name: dbus
-      - mountPath: /run/systemd
+      - mountPath: /run/systemd/system
         name: systemd
       - mountPath: /usr/local/bin/
         name: local-bin
@@ -41,11 +41,11 @@ spec:
           type: DirectoryOrCreate
         name: enclave-cc-artifacts
       - hostPath:
-          path: /var/run/dbus
+          path: /var/run/dbus/system_bus_socket
           type: ""
         name: dbus
       - hostPath:
-          path: /run/systemd
+          path: /run/systemd/system
           type: ""
         name: systemd
       - hostPath:
@@ -63,9 +63,9 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
-        - mountPath: /var/run/dbus
+        - mountPath: /var/run/dbus/system_bus_socket
           name: dbus
-        - mountPath: /run/systemd
+        - mountPath: /run/systemd/system
           name: systemd
       volumes:
         - hostPath:

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -77,23 +77,23 @@ spec:
             type: ""
           name: etc-systemd-system
         - hostPath:
-            path: /var/run/dbus
+            path: /var/run/dbus/system_bus_socket
             type: ""
           name: dbus
         - hostPath:
-            path: /run/systemd
+            path: /run/systemd/system
             type: ""
           name: systemd
     preInstall:
-      image: quay.io/confidential-containers/container-engine-for-cc-payload:1def978fdf6b0cb2383d43970c3dc484df3cad54
+      image: quay.io/confidential-containers/container-engine-for-cc-payload:98a790e8abdcc06c4b629b290ebaa217bf82e305
       volumeMounts:
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
-        - mountPath: /var/run/dbus
+        - mountPath: /var/run/dbus/system_bus_socket
           name: dbus
-        - mountPath: /run/systemd
+        - mountPath: /run/systemd/system
           name: systemd
       volumes:
         - hostPath:
@@ -105,11 +105,11 @@ spec:
             type: ""
           name: etc-systemd-system
         - hostPath:
-            path: /var/run/dbus
+            path: /var/run/dbus/system_bus_socket
             type: ""
           name: dbus
         - hostPath:
-            path: /run/systemd
+            path: /run/systemd/system
             type: ""
           name: systemd
     environmentVariables:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload
-  newTag: enclave-cc-SIM-v0.4.0
+- name: quay.io/confidential-containers/runtime-payload-ci
+  newTag: enclave-cc-SIM-4370700439f5524a60cf7a31c7c4f92bbe4dd655

--- a/docs/PAYLOAD_IMAGE.md
+++ b/docs/PAYLOAD_IMAGE.md
@@ -30,9 +30,9 @@ Following is an example for Kata runtime depicting the key attributes.
         name: containerd-conf
       - mountPath: /opt/confidential-containers/
         name: kata-artifacts
-      - mountPath: /var/run/dbus
+      - mountPath: /var/run/dbus/system_bus_socket
         name: dbus
-      - mountPath: /run/systemd
+      - mountPath: /run/systemd/system
         name: systemd
       - mountPath: /usr/local/bin/
         name: local-bin
@@ -46,11 +46,11 @@ Following is an example for Kata runtime depicting the key attributes.
           type: DirectoryOrCreate
         name: kata-artifacts
       - hostPath:
-          path: /var/run/dbus
+          path: /var/run/dbus/system_bus_socket
           type: ""
         name: dbus
       - hostPath:
-          path: /run/systemd
+          path: /run/systemd/system
           type: ""
         name: systemd
       - hostPath:

--- a/tests/e2e/kind/Dockerfile
+++ b/tests/e2e/kind/Dockerfile
@@ -1,0 +1,10 @@
+ARG IMAGE=kindest/node
+ARG VERSION=1.26
+ARG MINOR=0
+
+FROM ${IMAGE}:v${VERSION}.${MINOR}
+
+RUN echo "Installing Packages ..." \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends dbus \
+    && systemctl enable dbus


### PR DESCRIPTION
---

enclave-cc: Fix preInstall image tag / hostPath / mountPath

We've updated the preInstall image to use Ubuntu 20.04 instead of
CentOS, but we didn't fully reflect the changes for Enclave CC.

---

payloads: Update to an image using ubuntu as base

Both Enclave CC and Kata Containers have switched to using a base image
for their payloads, and we should make sure it works on our side.

As part of the change, we need to update the hostPath / mountPath to
reflect what's needed in order to be able to call `systemctl restart
...` using the new Ubuntu base image.

---