### PR TITLE
Fix docker rate limit

### DIFF
--- a/tests/e2e/ansible/start_docker_registry.yml
+++ b/tests/e2e/ansible/start_docker_registry.yml
@@ -25,7 +25,7 @@
       docker_container:
         name: "{{ local_registry_name }}"
         # TODO: docker.io is troublesome as we can hit the pull limits.
-        image: docker.io/library/registry:latest
+        image: docker.io/library/registry:2.8.1
         ports:
           - "{{ local_registry_port }}:{{ local_registry_port }}"
         state: started


### PR DESCRIPTION
Changing registry to a fixed version so that we will not hit the docker hub rate limit.

Fixes: #182