### PR TITLE
Add kata-qemu-snp runtime class

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -214,6 +214,7 @@ metadata:
                 "kata-clh-tdx-eaa-kbc"
                 "kata-qemu",
                 "kata-qemu-sev",
+                "kata-qemu-snp",
                 "kata-qemu-tdx",
                 "kata-qemu-tdx-eaa-kbc",
                 "kata-remote"

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -17,6 +17,6 @@ patches:
 - patch: |-
     - op: replace
       path: /spec/config/runtimeClassNames
-      value: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx", "kata-qemu-sev"]
+      value: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx", "kata-qemu-sev", "kata-qemu-snp"]
   target:
     kind: CcRuntime

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -135,6 +135,7 @@ kata-clh-tdx    kata-clh-tdx    9m55s
 kata-qemu       kata-qemu       9m55s
 kata-qemu-tdx   kata-qemu-tdx   9m55s
 kata-qemu-sev   kata-qemu-sev   9m55s
+kata-qemu-snp   kata-qemu-snp   9m55s
 ```
 
 ## Changing Runtime bundle


### PR DESCRIPTION
Following the example of kata-qemu-sev, add kata-qemu-snp where needed. This will result in a runtime class being defined and kata-deploy.sh configuring containerd and shim for kata-qemu-snp.

Fixes: kata-containers/kata-containers#6547

Depends on all the other PRs listed in #146