### PR TITLE
config: Add runtimeclass kata-qemu-se

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -214,6 +214,7 @@ metadata:
                 "kata-clh-tdx-eaa-kbc"
                 "kata-qemu",
                 "kata-qemu-sev",
+                "kata-qemu-se",
                 "kata-qemu-tdx",
                 "kata-qemu-tdx-eaa-kbc",
                 "kata-remote"

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -6,10 +6,15 @@ nameSuffix: -s390x
 resources:
 - ../default
 
+images:
+- name: quay.io/confidential-containers/runtime-payload
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-128f0282e11fb33f648c0ecf1d75a40f13985e01
+
 patches:
 - patch: |-
     - op: replace
       path: /spec/config/runtimeClassNames
-      value: ["kata", "kata-qemu"]
+      value: ["kata", "kata-qemu", "kata-qemu-se"]
   target:
     kind: CcRuntime

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -122,6 +122,10 @@ main() {
 			echo "INFO: Running non-TEE tests for $runtimeclass using OfflineFS KBC"
 			run_non_tee_tests "$runtimeclass"
 			;;
+		kata-qemu-se)
+			echo "INFO: Running TEE (IBM SE) tests for $runtimeclass using OfflineFS KBC"
+			run_non_tee_tests "$runtimeclass"
+			;;
 		kata-qemu-tdx)
 			echo "INFO: Running non-TEE tests for $runtimeclass using CC KBC"
 			run_non_tee_tests "$runtimeclass" "cc_kbc"


### PR DESCRIPTION
This is to add a new runtimeclass `kata-qemu-se` and update its payload image for e2e test.

Fixes: #190

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>