### PR TITLE
tests: Switch to cc_kbc for kata-qemu-tdx runtime

### DIFF
--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -123,8 +123,8 @@ main() {
 			run_non_tee_tests "$runtimeclass"
 			;;
 		kata-qemu-tdx)
-			echo "INFO: Running non-TEE tests for $runtimeclass using EAA KBC"
-			run_non_tee_tests "$runtimeclass" "eaa_kbc"
+			echo "INFO: Running non-TEE tests for $runtimeclass using CC KBC"
+			run_non_tee_tests "$runtimeclass" "cc_kbc"
 			;;
 		kata-qemu-sev)
 			echo "INFO: Running kata-qemu-sev tests for $runtimeclass"


### PR DESCRIPTION
CoCo v0.5.0 payload will install cc_kbc for kata-qemu-tdx runtime by default, operator CI tests also need updates accordingly.

Fixes: #198