### PR TITLE
Update payloads to what will become v0.5.0

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-121892ec61cb7d50c662133bb6fbf25b50ab676e-x86_64
+  newTag: kata-containers-e58ccb632fd95b7d83bfe85fba5ad79b1c03baaf-x86_64
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 images:
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-121892ec61cb7d50c662133bb6fbf25b50ab676e-s390x
+  newTag: kata-containers-e58ccb632fd95b7d83bfe85fba5ad79b1c03baaf-s390x
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-4370700439f5524a60cf7a31c7c4f92bbe4dd655
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-8f8592e0d4949556b3a896c2312e4ffe51309dab
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -5,4 +5,4 @@ nameSuffix: -sgx-mode-sim
 
 images:
 - name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-4370700439f5524a60cf7a31c7c4f92bbe4dd655
+  newTag: enclave-cc-SIM-8f8592e0d4949556b3a896c2312e4ffe51309dab

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -123,8 +123,8 @@ main() {
 			run_non_tee_tests "$runtimeclass"
 			;;
 		kata-qemu-tdx)
-			echo "INFO: Running non-TEE tests for $runtimeclass using EAA KBC"
-			run_non_tee_tests "$runtimeclass" "eaa_kbc"
+			echo "INFO: Running non-TEE tests for $runtimeclass using CC KBC"
+			run_non_tee_tests "$runtimeclass" "cc_kbc"
 			;;
 		kata-qemu-sev)
 			echo "INFO: Running kata-qemu-sev tests for $runtimeclass"


### PR DESCRIPTION
I'm updating the Enclave CC and Kata Containers payload.
There's no change on the pre-install payloads since the last bump.