### PR TITLE
tests/e2e: downgrade requests package if needed

### DIFF
--- a/tests/e2e/ansible/start_docker_registry.yml
+++ b/tests/e2e/ansible/start_docker_registry.yml
@@ -24,9 +24,12 @@
     # Due to a bug in requests 2.29.0 we need to downgrade it
     # see https://github.com/docker/docker-py/issues/3113 
     - name: Downgrade requests
-      pip: 
-        name: requests
-        version: 2.28.1
+      shell: |
+        actual_version="$(pip3 show requests | grep Version | cut -d: -f2 | xargs)"
+        version_ge="$(echo -e "2.29.0\n$actual_version" | sort -V | head -1)"
+        if [ "$version_ge" = "2.29.0" ]; then
+            pip3 install requests==2.28.1
+        fi
     - name: Start a docker registry
       docker_container:
         name: "{{ local_registry_name }}"


### PR DESCRIPTION
I ran into that issue while trying to build an environment within CentOS Stream 8, there the requests package is at 2.27.1 version.

---

The distro might have requests < 2.29.0 already so that the package doesn't need to be downgraded. Actually an attempt to downgrade it fail the playbook.

Fixes #206
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>