### PR TITLE
Payload: update payload images to 0.6.0

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-947466ce98e5a2d7ecb3f91f919f83296f5ce019
+  newTag: kata-containers-338e18e4fd46756643cb1a307b6a20f24c350ad4
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-947466ce98e5a2d7ecb3f91f919f83296f5ce019
+  newTag: kata-containers-338e18e4fd46756643cb1a307b6a20f24c350ad4
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-ab94b7f0c81615c40fab3ae3b28986909e4f1bd2
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-c4466f67c98f24312e2f53a5a3ebe9669d88fa5e
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -5,4 +5,4 @@ nameSuffix: -sgx-mode-sim
 
 images:
 - name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-sample-kbc-ab94b7f0c81615c40fab3ae3b28986909e4f1bd2
+  newTag: enclave-cc-SIM-sample-kbc-c4466f67c98f24312e2f53a5a3ebe9669d88fa5e


### PR DESCRIPTION
Update the payloads for Kata-Containers and Enclave-CC to the ones built from the subcomponents tagged for 0.6.0.

This is step 15 and 16 from https://github.com/confidential-containers/community/issues/93