### PR TITLE
Bump tags for release v0.6.0

### DIFF
--- a/config/release/kustomization.yaml
+++ b/config/release/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 # newTag points to the latest release image and must be updated before tagging a new release
 images:
 - name: quay.io/confidential-containers/operator
-  newTag: v0.5.0
+  newTag: v0.6.0

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-947466ce98e5a2d7ecb3f91f919f83296f5ce019
+  newName: quay.io/confidential-containers/runtime-payload
+  newTag: kata-containers-338e18e4fd46756643cb1a307b6a20f24c350ad4
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: 98a790e8abdcc06c4b629b290ebaa217bf82e305
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-947466ce98e5a2d7ecb3f91f919f83296f5ce019
+  newName: quay.io/confidential-containers/runtime-payload
+  newTag: kata-containers-338e18e4fd46756643cb1a307b6a20f24c350ad4
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node-role.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-ab94b7f0c81615c40fab3ae3b28986909e4f1bd2
+    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-cc-kbc-v0.6.1
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-sample-kbc-ab94b7f0c81615c40fab3ae3b28986909e4f1bd2
+- name: quay.io/confidential-containers/runtime-payload
+  newTag: enclave-cc-SIM-sample-kbc-v0.6.1


### PR DESCRIPTION
Update the payloads and the tag for the operator. 

Note the change to the enclave-cc sim payload. Is this correct? @mythi 