### PR TITLE
containerd: switch to the right gpg key url

### DIFF
--- a/install/pre-install-payload/containerd/Dockerfile
+++ b/install/pre-install-payload/containerd/Dockerfile
@@ -17,7 +17,7 @@ RUN \
 apt-get update && \
 apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl xz-utils systemd && \
 mkdir -p /etc/apt/keyrings/ && \
-curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
+curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg && \
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
 apt-get update && \
 apt-get install -y --no-install-recommends kubectl && \


### PR DESCRIPTION
The google url fails with an error of public key not available, hence switch it to the right one.

Fixes: #221