### PR TITLE
Update artifacts to release candidates built with tags

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: c80c3e7392c1562841e75072d227e07f98cab2bd
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-9e036108b4d5d9344eedcd2a5dac78d316b79cac
+  newTag: kata-containers-f5420e5cf198eb54585dad9fb63eb2eaaff3e5a8
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: c80c3e7392c1562841e75072d227e07f98cab2bd 
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-9e036108b4d5d9344eedcd2a5dac78d316b79cac
+  newTag: kata-containers-f5420e5cf198eb54585dad9fb63eb2eaaff3e5a8
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-a34d06fc31aa6bcd1008faba41b1632d7338dc99
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-10b9bf4a2d5f9c5401f23522c15a008295e15dc3
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -5,4 +5,4 @@ nameSuffix: -sgx-mode-sim
 
 images:
 - name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-sample-kbc-a34d06fc31aa6bcd1008faba41b1632d7338dc99
+  newTag: enclave-cc-SIM-sample-kbc-10b9bf4a2d5f9c5401f23522c15a008295e15dc3


### PR DESCRIPTION
Very similar to the last update, but these bundles were built using the tagged version of the subcomponents.

Step 17 of https://github.com/confidential-containers/confidential-containers/issues/111