### PR TITLE
Update artifacts to v0.7.0 release bundles

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: c80c3e7392c1562841e75072d227e07f98cab2bd
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-f5420e5cf198eb54585dad9fb63eb2eaaff3e5a8
+  newName: quay.io/confidential-containers/runtime-payload
+  newTag: kata-containers-16d6e37196cb5c18ca5e718549f7a747658105a2
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: c80c3e7392c1562841e75072d227e07f98cab2bd 
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-f5420e5cf198eb54585dad9fb63eb2eaaff3e5a8
+  newName: quay.io/confidential-containers/runtime-payload
+  newTag: kata-containers-16d6e37196cb5c18ca5e718549f7a747658105a2
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-10b9bf4a2d5f9c5401f23522c15a008295e15dc3
+    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-cc-kbc-v0.7.0
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-sample-kbc-10b9bf4a2d5f9c5401f23522c15a008295e15dc3
+- name: quay.io/confidential-containers/runtime-payload
+  newTag: enclave-cc-SIM-sample-kbc-v0.7.0


### PR DESCRIPTION
These are the bundles corresponding to the v0.7.0 tags for CCv0 and enclave-cc. 

Step 23 or https://github.com/confidential-containers/confidential-containers/issues/111