### PR TITLE
release: bump operator version to v0.7.0

### DIFF
--- a/config/release/kustomization.yaml
+++ b/config/release/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 # newTag points to the latest release image and must be updated before tagging a new release
 images:
 - name: quay.io/confidential-containers/operator
-  newTag: v0.6.0
+  newTag: v0.7.0


### PR DESCRIPTION
Step 24 of https://github.com/confidential-containers/confidential-containers/issues/111