### PR TITLE
ccruntime: Adapt to the kata payload using `/opt/kata`

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -51,7 +51,7 @@ metadata:
                   "name": "containerd-conf"
                 },
                 {
-                  "mountPath": "/opt/confidential-containers/",
+                  "mountPath": "/opt/kata/",
                   "name": "kata-artifacts"
                 },
                 {
@@ -77,7 +77,7 @@ metadata:
                 },
                 {
                   "hostPath": {
-                    "path": "/opt/confidential-containers/",
+                    "path": "/opt/kata/",
                     "type": "DirectoryOrCreate"
                   },
                   "name": "kata-artifacts"

--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -20,7 +20,7 @@ spec:
         name: crio-conf
       - mountPath: /etc/containerd/
         name: containerd-conf
-      - mountPath: /opt/confidential-containers/
+      - mountPath: /opt/kata/
         name: kata-artifacts
       - mountPath: /var/run/dbus/system_bus_socket
         name: dbus
@@ -38,7 +38,7 @@ spec:
           type: ""
         name: containerd-conf
       - hostPath:
-          path: /opt/confidential-containers/
+          path: /opt/kata/
           type: DirectoryOrCreate
         name: kata-artifacts
       - hostPath:

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: c80c3e7392c1562841e75072d227e07f98cab2bd
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-16d6e37196cb5c18ca5e718549f7a747658105a2
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/container-engine-for-cc-payload
   newTag: c80c3e7392c1562841e75072d227e07f98cab2bd 
 - name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload
-  newTag: kata-containers-16d6e37196cb5c18ca5e718549f7a747658105a2
+  newName: quay.io/confidential-containers/runtime-payload-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 images:
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-128f0282e11fb33f648c0ecf1d75a40f13985e01
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-cc-kbc-v0.7.0
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-latest
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload
-  newTag: enclave-cc-SIM-sample-kbc-v0.7.0
+- name: quay.io/confidential-containers/runtime-payload-ci
+  newTag: enclave-cc-SIM-sample-kbc-latest

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -81,7 +81,7 @@ run_non_tee_tests() {
 	# to get the path to kata's configuration.toml and image files. Without this
 	# they will change the default configuration.toml, which doesn't correspond to
 	# the one used by the runtimeclass, therefore, performing bogus changes.
-	local runtime_config_file="/opt/confidential-containers/share/defaults/kata-containers/"
+	local runtime_config_file="/opt/kata/share/defaults/kata-containers/"
 	runtime_config_file+="configuration-${runtimeclass/kata-/}.toml"
 	sed -i "s#kata-runtime kata-env#kata-runtime --config $runtime_config_file kata-env#g" \
 		../../../lib/common.bash
@@ -118,7 +118,7 @@ main() {
 	# Test scripts rely on kata-runtime so it should be reacheable on PATH.
 	# Re-export PATH is error prone as some calls to kata-runtime use sudo,
 	# so let's create a symlink.
-	ln -sf /opt/confidential-containers/bin/kata-runtime \
+	ln -sf /opt/kata/bin/kata-runtime \
 		/usr/local/bin/kata-runtime
 
 	# Run tests.


### PR DESCRIPTION
This is a change that's been done as part of the CCv0, and it'll simplify a lot the co-existence of the `CCv0` and `main` branch during this time that we're moving things from `CCv0` to `main`.


This pull request is marked as a Draft because it depends on https://github.com/kata-containers/kata-containers/pull/7402 getting merged and having a payload generated from it.