### PR TITLE
CRD: Expose more options to the users and let the payload take care of the runtime class creation

### DIFF
--- a/api/v1beta1/ccruntime_types.go
+++ b/api/v1beta1/ccruntime_types.go
@@ -162,6 +162,10 @@ type CcInstallConfig struct {
 	// +optional
 	RuntimeClassNames []string `json:"runtimeClassNames,omitempty"`
 
+	// This specifies whether the CcRuntime (kata or enclave-cc) will be running on debug mode
+	// +optional
+	Debug bool `json:"debug,omitempty"`
+
 	// This specifies the environment variables required by the daemon set
 	// +optional
 	EnvironmentVariables []corev1.EnvVar `json:"environmentVariables,omitempty"`

--- a/api/v1beta1/ccruntime_types.go
+++ b/api/v1beta1/ccruntime_types.go
@@ -162,6 +162,12 @@ type CcInstallConfig struct {
 	// +optional
 	RuntimeClassNames []string `json:"runtimeClassNames,omitempty"`
 
+	// This specifies the RuntimeClass to be used as the default one
+	// If not set, the default "kata" runtime class will NOT be created. Otherwise, the default "kata" runtime class will be created
+	// as as "alias" for the value set here
+	// +optional
+	DefaultRuntimeClassName string `json:"defaultRuntimeClassName,omitempty"`
+
 	// This specifies whether the CcRuntime (kata or enclave-cc) will be running on debug mode
 	// +optional
 	Debug bool `json:"debug,omitempty"`

--- a/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
+++ b/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
@@ -102,6 +102,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  debug:
+                    description: This specifies whether the CcRuntime (kata or enclave-cc)
+                      will be running on debug mode
+                    type: boolean
                   environmentVariables:
                     description: This specifies the environment variables required
                       by the daemon set

--- a/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
+++ b/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
@@ -106,6 +106,12 @@ spec:
                     description: This specifies whether the CcRuntime (kata or enclave-cc)
                       will be running on debug mode
                     type: boolean
+                  defaultRuntimeClassName:
+                    description: This specifies the RuntimeClass to be used as the
+                      default one If not set, the default "kata" runtime class will
+                      NOT be created. Otherwise, the default "kata" runtime class
+                      will be created as as "alias" for the value set here
+                    type: string
                   environmentVariables:
                     description: This specifies the environment variables required
                       by the daemon set

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -17,6 +17,12 @@ patches:
 - patch: |-
     - op: replace
       path: /spec/config/runtimeClassNames
-      value: ["kata", "kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx", "kata-qemu-sev", "kata-qemu-snp"]
+      value: ["kata-clh", "kata-clh-tdx", "kata-qemu", "kata-qemu-tdx", "kata-qemu-sev", "kata-qemu-snp"]
+    - op: add
+      path: /spec/config/defaultRuntimeClassName
+      value: "kata-qemu"
+    - op: add
+      path: /spec/config/debug
+      value: false
   target:
     kind: CcRuntime

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -18,5 +18,8 @@ patches:
     - op: replace
       path: /spec/config/runtimeClassNames
       value: ["kata-remote"]
+    - op: add
+      path: /spec/config/debug
+      value: false
   target:
     kind: CcRuntime

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -15,6 +15,12 @@ patches:
 - patch: |-
     - op: replace
       path: /spec/config/runtimeClassNames
-      value: ["kata", "kata-qemu", "kata-qemu-se"]
+      value: ["kata-qemu", "kata-qemu-se"]
+    - op: add
+      path: /spec/config/defaultRuntimeClassName
+      value: "kata-qemu"
+    - op: add
+      path: /spec/config/debug
+      value: false
   target:
     kind: CcRuntime

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -654,10 +654,26 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 
 	var debug = strconv.FormatBool(r.ccRuntime.Spec.Config.Debug)
 
+	var defaultShim = ""
+	var createDefaultRuntimeClass = "false"
+	if strings.HasPrefix(r.ccRuntime.Spec.Config.DefaultRuntimeClassName, "kata-") {
+		// Remove the "kata-" prefix from DefaultRuntimeClassName
+		defaultShim = strings.TrimPrefix(r.ccRuntime.Spec.Config.DefaultRuntimeClassName, "kata-")
+		createDefaultRuntimeClass = "true"
+	}
+
 	var envVars = []corev1.EnvVar{
 		{
 			Name:  "DEBUG",
 			Value: debug,
+		},
+		{
+			Name:  "DEFAULT_SHIM",
+			Value: defaultShim,
+		},
+		{
+			Name:  "CREATE_DEFAULT_RUNTIMECLASS",
+			Value: createDefaultRuntimeClass,
 		},
 	}
 	envVars = append(envVars, r.ccRuntime.Spec.Config.EnvironmentVariables...)

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -651,6 +652,16 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 		containerCommand = r.ccRuntime.Spec.Config.UninstallCmd
 	}
 
+	var debug = strconv.FormatBool(r.ccRuntime.Spec.Config.Debug)
+
+	var envVars = []corev1.EnvVar{
+		{
+			Name:  "DEBUG",
+			Value: debug,
+		},
+	}
+	envVars = append(envVars, r.ccRuntime.Spec.Config.EnvironmentVariables...)
+
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -692,7 +703,7 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 								RunAsUser:  &runAsUser,
 							},
 							Command:      containerCommand,
-							Env:          r.ccRuntime.Spec.Config.EnvironmentVariables,
+							Env:          envVars,
 							VolumeMounts: r.ccRuntime.Spec.Config.InstallerVolumeMounts,
 						},
 					},


### PR DESCRIPTION
In this PR we're exposing a few new attributes to the users:
* `Debug`: Whether to enable `debug` for the runtime configuretion, which will also properly configure the CRI Engine accordingly
* `DefaultRuntimeClassName`: The runtime class name that will be used as the default one, and will become the `kata` alias.

Together with these 2 options being exposed, we're leaving the runtime class creation to the runtime payloads, as they know better than the Operator what are the possible podOverhead and, in the future, NFD rules to be used.

Right now this is a draft as it depends on content that's not yet part of the Kata Containers payload, and also work that's been ongoing on the Enclave CC side (thanks @mythi for that!).  Regardless, I'd love to hear feedback from the other operator maintainers, thus I'm looping them here.