### PR TITLE
crd: Expose "UsingNFD" to the CcInstallConfig

### DIFF
--- a/api/v1beta1/ccruntime_types.go
+++ b/api/v1beta1/ccruntime_types.go
@@ -172,6 +172,10 @@ type CcInstallConfig struct {
 	// +optional
 	Debug bool `json:"debug,omitempty"`
 
+	// This specified whether NodeFeatureDiscovery is being used or not, and relies on its feataures in case it is.
+	// +optional
+	UsingNFD bool `json:"usingNFD,omitempty"`
+
 	// This specifies the environment variables required by the daemon set
 	// +optional
 	EnvironmentVariables []corev1.EnvVar `json:"environmentVariables,omitempty"`

--- a/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
+++ b/config/crd/bases/confidentialcontainers.org_ccruntimes.yaml
@@ -5701,6 +5701,10 @@ spec:
                     description: This specifies the label that the uninstall daemonset
                       adds to nodes when the uninstallation  is done
                     type: object
+                  usingNFD:
+                    description: This specified whether NodeFeatureDiscovery is being
+                      used or not, and relies on its feataures in case it is.
+                    type: boolean
                 required:
                 - installType
                 - payloadImage

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -603,6 +603,8 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 	var runtimeClasses = strings.Join(r.ccRuntime.Spec.Config.RuntimeClassNames, " ")
 	var shims = strings.ReplaceAll(runtimeClasses, "kata-", "")
 
+	var usingNFD = strconv.FormatBool(r.ccRuntime.Spec.Config.UsingNFD)
+
 	var envVars = []corev1.EnvVar{
 		{
 			Name:  "DEBUG",
@@ -623,6 +625,10 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 		{
 			Name:  "SHIMS",
 			Value: shims,
+		},
+		{
+			Name:  "USING_NFD",
+			Value: usingNFD,
 		},
 	}
 	envVars = append(envVars, r.ccRuntime.Spec.Config.EnvironmentVariables...)


### PR DESCRIPTION
Let's have a explicit toggle that allows users to specify whether they're relying on NFD or not.

In case they're not relying on NFD, business as usual.  In case they are, then the runtime payload will be able to create a specific NodeFeatureRule, adapt the podOverhead of the runtime class, and make sure the keys book-keeping is correctly done.

Right now, on the Kata Containers side of the things, only TDX is capable of doing so, but it's easy to expand in case other TEEs want to do the same.