### PR TITLE
controller: Ensure the runtimeclass was created by the payload

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,6 +14,7 @@ jobs:
     services:
       registry:
         image: registry:2
+        options: --name registry
         ports:
           - 5000:5000
     steps:
@@ -42,6 +43,7 @@ jobs:
         run: |
           kind create cluster --image "kindest/node:v1.27.3-coco" -n coco-sgx --config tests/e2e/enclave-cc-kind-config.yaml --wait 120s
           kubectl label node coco-sgx-worker node.kubernetes.io/worker=
+          docker network connect kind registry
 
       - name: Deploy operator from the local registry
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,3 +65,11 @@ jobs:
         run: |
           kubectl apply -f tests/e2e/enclave-cc-pod-sim.yaml
           kubectl wait --for=condition=Ready pod/enclave-cc-pod-sim
+
+      - name: Debug
+        if: always()
+        shell: bash
+        run: |
+          set -x
+          kubectl get pods -A
+          kubectl get runtimeclass

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,10 +46,12 @@ jobs:
       - name: Deploy operator from the local registry
         run: |
           cd config/default
-          kustomize edit set image localhost:5000/cc-operator:latest
+          kustomize edit set image quay.io/confidential-containers/operator=localhost:5000/cc-operator:latest
           kubectl apply -k .
           sleep 1
           kubectl wait --for=jsonpath='{.status.conditions[0].status}'=True deployments/cc-operator-controller-manager -n confidential-containers-system
+          img=$(kubectl get deployments/cc-operator-controller-manager -n confidential-containers-system -o jsonpath='{.spec.template.spec.containers[?(@.name == "manager")].image}')
+          [ "${img}" = "localhost:5000/cc-operator:latest" ]
 
       - name: Install enclave-cc sim
         run: |

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	nodeapi "k8s.io/api/node/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -463,6 +464,18 @@ func (r *CcRuntimeReconciler) monitorCcRuntimeInstallation() (ctrl.Result, error
 
 	// If the installation of the binaries is successful on all nodes, proceed with creating the runtime classes
 	if r.allNodesInstalled() {
+		// Update runtimeClass field
+		runtimeClassNames := r.ccRuntime.Spec.Config.RuntimeClassNames
+		for _, runtimeClassName := range runtimeClassNames {
+			foundRc := &nodeapi.RuntimeClass{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: runtimeClassName}, foundRc)
+			if errors.IsNotFound(err) {
+				r.Log.Info("The runtime payload failed to creathe the runtime class named %s", runtimeClassName)
+				return ctrl.Result{}, err
+			}
+		}
+		r.ccRuntime.Status.RuntimeClass = strings.Join(runtimeClassNames, ",")
+
 		// Add finalizer for this CR
 		if !contains(r.ccRuntime.GetFinalizers(), RuntimeConfigFinalizer) {
 			if err := r.addFinalizer(); err != nil {

--- a/tests/e2e/enclave-cc-kind-config.yaml
+++ b/tests/e2e/enclave-cc-kind-config.yaml
@@ -9,4 +9,4 @@ nodes:
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["http://localhost:5000"]
+    endpoint = ["http://registry:5000"]


### PR DESCRIPTION
36664b5658065f0d3de46d7497c69518c8ce6beb introduced a regression as the runtimeClass creation was left to the runtime payload, but we never checked whether this actually was created neither updated the status on the Operator side.