### PR TITLE
docs: standardizing variable calls

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ The default CR can be created as shown below where `<RELEASE_VERSION>` needs to 
 desired [release tag](https://github.com/confidential-containers/operator/tags):
 
 ```
-kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/default?ref=<RELEASE_VERSION>
+kubectl apply -k github.com/confidential-containers/operator/config/samples/ccruntime/default?ref=${RELEASE_VERSION}
 ```
 
 Wait until each pod has the `STATUS` as `Running`:
@@ -160,7 +160,7 @@ kubectl apply -k config/samples/ccruntime/<MY_CUSTOM_CR>
 
 ### Delete the CR
 ```
-kubectl delete -k github.com/confidential-containers/operator/config/samples/ccruntime/default?ref=<RELEASE_VERSION>
+kubectl delete -k github.com/confidential-containers/operator/config/samples/ccruntime/default?ref=${RELEASE_VERSION}
 ```
 
 ### Delete the Operator


### PR DESCRIPTION
At the documentation, the variables are called in different ways, but executing in a "$<>" standard, it appears to occur the error:
````
sh: Syntax error: newline expected
````

Changing the way it's made by "${}" solves the problem.