### PR TITLE
pre-install: Setup nydus-snapshotter

### DIFF
--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -55,6 +55,8 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
+        - mountPath: /etc/containerd/
+          name: containerd-conf
       volumes:
         - hostPath:
             path: /opt/confidential-containers/
@@ -64,6 +66,10 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
       environmentVariables:
         # If set to true, this will install the CoCo fork of the containerd,
         # the one allowing images to be pulled inside the guest and has patches
@@ -80,6 +86,11 @@ spec:
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
           value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
+          value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -87,6 +98,8 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
+        - mountPath: /etc/containerd/
+          name: containerd-conf
       volumes:
         - hostPath:
             path: /opt/confidential-containers/
@@ -96,6 +109,10 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
       environmentVariables:
         # If set to true, this will install the CoCo fork of the containerd,
         # the one allowing images to be pulled inside the guest and has patches
@@ -110,6 +127,11 @@ spec:
         # the one that has patches for handling GPU / VFIO, on the node
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
           value: "false"
     environmentVariables:
       - name: NODE_NAME

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -49,11 +49,17 @@ spec:
     postUninstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
+        - mountPath: /etc/containerd/
+          name: containerd-conf
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
       volumes:
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
         - hostPath:
             path: /opt/confidential-containers/
             type: DirectoryOrCreate
@@ -75,15 +81,26 @@ spec:
         # the one that has patches for handling GPU / VFIO, on the node
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
           value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
+        - mountPath: /etc/containerd/
+          name: containerd-conf
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
       volumes:
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
         - hostPath:
             path: /opt/confidential-containers/
             type: DirectoryOrCreate
@@ -105,6 +122,11 @@ spec:
         # the one that has patches for handling GPU / VFIO, on the node
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
           value: "false"
     environmentVariables:
       - name: NODE_NAME

--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -54,6 +54,40 @@ RUN \
 	tar xvzpf containerd-${VFIO_GPU_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${NODE_DESTINATION} && \
 	rm containerd-${VFIO_GPU_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
 
+#### Nydus snapshotter & nydus image
+
+FROM golang:1.19-alpine AS nydus-binary-downloader
+
+ARG ARCH
+ARG NYDUS_SNAPSHOTTER_VERSION
+ARG NYDUS_SNAPSHOTTER_REPO
+ARG NYDUS_REPO
+ARG NYDUS_VERSION
+
+ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
+ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
+
+ENV GOARCH=${ARCH}
+
+RUN mkdir -p ${NODE_DESTINATION}/bin && \
+    apk add --no-cache ca-certificates build-base git curl && \
+    git clone ${NYDUS_SNAPSHOTTER_REPO} -b ${NYDUS_SNAPSHOTTER_VERSION} /nydus-snapshotter && \
+    make -C /nydus-snapshotter && \
+    chmod +x /nydus-snapshotter/bin/containerd-nydus-grpc && \
+	chmod +x /nydus-snapshotter/bin/nydus-overlayfs && \
+    mv /nydus-snapshotter/bin/containerd-nydus-grpc ${NODE_DESTINATION}/bin && \
+	mv /nydus-snapshotter/bin/nydus-overlayfs ${NODE_DESTINATION}/bin && \
+    rm -rf /nydus-snapshotter 
+
+RUN if [ "${ARCH}" != "s390x" ]; then \
+    curl -fOL --progress-bar ${NYDUS_REPO}/releases/download/${NYDUS_VERSION}/nydus-static-${NYDUS_VERSION}-linux-${ARCH}.tgz && \
+    tar xvzpf nydus-static-${NYDUS_VERSION}-linux-${ARCH}.tgz -C / && \
+    chmod +x /nydus-static/nydus-image && \
+    mv /nydus-static/nydus-image ${NODE_DESTINATION}/bin && \
+    rm -rf /nydus-static /nydus-static-${NYDUS_VERSION}-linux-${ARCH}.tgz; \
+	fi
+
+RUN apk del build-base git curl
 
 #### kubectl
 
@@ -78,12 +112,17 @@ ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
 ARG NODE_CONTAINERD_SYSTEMD_DESTINATION=${DESTINATION}/etc/systemd/system/containerd.service.d/
 
 ARG CONTAINERD_SYSTEMD_ARTIFACTS=./containerd/containerd-for-cc-override.conf
+ARG NYDUS_SNAPSHOTTER_ARTIFACTS=./remote-snapshotter/nydus-snapshotter
 
 COPY --from=coco-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/coco-containerd
 COPY --from=official-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/official-containerd
 COPY --from=vfio-gpu-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/vfio-gpu-containerd
+
+COPY --from=nydus-binary-downloader ${NODE_DESTINATION}/bin/* ${NODE_DESTINATION}/bin/
+
 COPY --from=kubectl-binary-downloader /usr/bin/kubectl /usr/bin/kubectl
 COPY ${CONTAINERD_SYSTEMD_ARTIFACTS} ${NODE_CONTAINERD_SYSTEMD_DESTINATION}
+COPY ${NYDUS_SNAPSHOTTER_ARTIFACTS}/* ${NODE_DESTINATION}/share/nydus-snapshotter/
 
 ARG CONTAINER_ENGINE_ARTIFACTS=./scripts
 COPY ${CONTAINER_ENGINE_ARTIFACTS}/* ${DESTINATION}/scripts/

--- a/install/pre-install-payload/Makefile
+++ b/install/pre-install-payload/Makefile
@@ -1,6 +1,8 @@
 COCO_CONTAINERD_VERSION = 1.6.8.2
 OFFICIAL_CONTAINERD_VERSION = 1.7.0
 VFIO_GPU_CONTAINERD_VERSION = 1.7.0.0
+NYDUS_SNAPSHOTTER_VERSION = v0.12.0
+NYDUS_VERSION= v2.2.3
 
 BASH = bash
 
@@ -8,4 +10,6 @@ reqs-image:
 	coco_containerd_version=$(COCO_CONTAINERD_VERSION) \
 	official_containerd_version=$(OFFICIAL_CONTAINERD_VERSION) \
 	vfio_gpu_containerd_version=$(VFIO_GPU_CONTAINERD_VERSION) \
+	nydus_snapshotter_version=${NYDUS_SNAPSHOTTER_VERSION} \
+	nydus_version=${NYDUS_VERSION} \
 	$(BASH) -x payload.sh

--- a/install/pre-install-payload/remote-snapshotter/nydus-snapshotter/config-coco-guest-pulling.toml
+++ b/install/pre-install-payload/remote-snapshotter/nydus-snapshotter/config-coco-guest-pulling.toml
@@ -1,0 +1,15 @@
+version = 1
+
+# Snapshotter's own home directory where it stores and creates necessary resources
+root = "/var/lib/containerd-nydus"
+
+# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+
+[daemon]
+# Enable proxy mode
+fs_driver = "proxy"
+
+[snapshot]
+# Insert Kata volume information to `Mount.Options`
+enable_kata_volume = true

--- a/install/pre-install-payload/remote-snapshotter/nydus-snapshotter/config-coco-host-sharing.toml
+++ b/install/pre-install-payload/remote-snapshotter/nydus-snapshotter/config-coco-host-sharing.toml
@@ -1,0 +1,40 @@
+
+version = 1
+# Snapshotter's own home directory where it stores and creates necessary resources
+root = "/var/lib/containerd-nydus"
+# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+# No nydusd daemon needed
+daemon_mode = "none"
+
+[daemon]
+# Use `blockdev` for tarfs
+fs_driver = "blockdev"
+# Path to nydus-image binary
+nydusimage_path = "/opt/confidential-containers/bin/nydus-image"
+
+[remote]
+skip_ssl_verify = true
+
+[snapshot]
+# Insert Kata volume information to `Mount.Options`
+enable_kata_volume = true
+
+[experimental.tarfs]
+# Whether to enable nydus tarfs mode. Tarfs is supported by:
+# - The EROFS filesystem driver since Linux 6.4
+# - Nydus Image Service release v2.3
+enable_tarfs = true
+
+# Mount rafs on host by loopdev and EROFS
+mount_tarfs_on_host = false
+
+# Mode to export tarfs images:
+# - "none" or "": do not export tarfs
+# - "layer_verity_only": only generate disk verity information for a layer blob
+# - "image_verity_only": only generate disk verity information for all blobs of an image
+# - "layer_block": generate a raw block disk image with tarfs for a layer
+# - "image_block": generate a raw block disk image with tarfs for an image
+# - "layer_block_with_verity": generate a raw block disk image with tarfs for a layer with dm-verity info
+# - "image_block_with_verity": generate a raw block disk image with tarfs for an image with dm-verity info
+export_mode = "image_block_with_verity"


### PR DESCRIPTION
This is a patch to setup remote snapshotter instead forked containerd in CoCo. As discussed in https://github.com/kata-containers/kata-containers/issues/7658, operator is responsible to set up the snapshotter.