### PR TITLE
pre-install: Do not try to remove /opt/confidential-containers

### DIFF
--- a/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
+++ b/install/pre-install-payload/scripts/container-engine-for-cc-deploy.sh
@@ -52,7 +52,6 @@ function uninstall_artifacts() {
 	rm -f /opt/confidential-containers/bin/containerd
 	echo "Removing the /opt/confidential-containers directory"
 	[ -d /opt/confidential-containers/bin ] && rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers/bin
-	[ -d /opt/confidential-containers ] && rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers
 }
 
 function restart_systemd_service() {


### PR DESCRIPTION
That's a HostPath mounted, and cannot be removed from within the container.

This may cause issues like:
```
Removing the /opt/confidential-containers directory
rmdir: failed to remove '/opt/confidential-containers': Device or resource busy
```