### PR TITLE
pre-install-payload: Use latest tagged runtime-payload image

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad0978b8e9f1acb857fe2c76f1494c55bf28e05
+  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-latest

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad0978b8e9f1acb857fe2c76f1494c55bf28e05
+  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-latest

--- a/config/samples/ccruntime/ssh-demo/kustomization.yaml
+++ b/config/samples/ccruntime/ssh-demo/kustomization.yaml
@@ -10,7 +10,7 @@ images:
 - name: quay.io/confidential-containers/runtime-payload
   newTag: kata-containers-ssh-demo-v0.2.0
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 1def978fdf6b0cb2383d43970c3dc484df3cad54
+  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 nameSuffix: -sgx-mode-hw
 
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad0978b8e9f1acb857fe2c76f1494c55bf28e05
+  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -7,4 +7,4 @@ images:
 - name: quay.io/confidential-containers/runtime-payload-ci
   newTag: enclave-cc-SIM-sample-kbc-latest
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad0978b8e9f1acb857fe2c76f1494c55bf28e05
+  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f


### PR DESCRIPTION
The tags for the quay.io/confidential-containers/reqs-payload image were not set to the latest tag and were set to the tag of an image that went into a crash loop when you ran it as part of the operator installation.

Fixes: #254 