### PR TITLE
pre-install-payload: Handle official and VFIO / GPU containerd installations

### DIFF
--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -75,6 +75,11 @@ spec:
         # default: false
         - name: "INSTALL_OFFICIAL_CONTAINERD"
           value: "false"
+        # If set to true, this will install the CoCo fork of the containerd,
+        # the one that has patches for handling GPU / VFIO, on the node
+        # default: false
+        - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -100,6 +105,11 @@ spec:
         # If set to true, this will install the v1.7.0 release of containerd on the node.
         # default: false
         - name: "INSTALL_OFFICIAL_CONTAINERD"
+          value: "false"
+        # If set to true, this will install the CoCo fork of the containerd,
+        # the one that has patches for handling GPU / VFIO, on the node
+        # default: false
+        - name: "INSTALL_VFIO_GPU_CONTAINERD"
           value: "false"
     environmentVariables:
       - name: NODE_NAME

--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -64,6 +64,13 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
+      environmentVariables:
+        # If set to true, this will install the CoCo fork of the containerd,
+        # the one allowing images to be pulled inside the guest and has patches
+        # for handling GPU / VFIO, on the node
+        # default: true
+        - name: "INSTALL_COCO_CONTAINERD"
+          value: "true"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -80,6 +87,12 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
+      environmentVariables:
+        # If set to true, this will install the CoCo fork of the containerd,
+        # the one allowing images to be pulled inside the guest and has patches
+        # for handling GPU / VFIO, on the node
+        - name: "INSTALL_COCO_CONTAINERD"
+          value: "true"
     environmentVariables:
       - name: NODE_NAME
         valueFrom:

--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -71,6 +71,10 @@ spec:
         # default: true
         - name: "INSTALL_COCO_CONTAINERD"
           value: "true"
+        # If set to true, this will install the v1.7.0 release of containerd on the node.
+        # default: false
+        - name: "INSTALL_OFFICIAL_CONTAINERD"
+          value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -93,6 +97,10 @@ spec:
         # for handling GPU / VFIO, on the node
         - name: "INSTALL_COCO_CONTAINERD"
           value: "true"
+        # If set to true, this will install the v1.7.0 release of containerd on the node.
+        # default: false
+        - name: "INSTALL_OFFICIAL_CONTAINERD"
+          value: "false"
     environmentVariables:
       - name: NODE_NAME
         valueFrom:

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -67,6 +67,10 @@ spec:
         # default: true
         - name: "INSTALL_COCO_CONTAINERD"
           value: "true"
+        # If set to true, this will install the v1.7.0 release of containerd on the node.
+        # default: false
+        - name: "INSTALL_OFFICIAL_CONTAINERD"
+          value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -88,6 +92,10 @@ spec:
         # default: true
         - name: "INSTALL_COCO_CONTAINERD"
           value: "true"
+        # If set to true, this will install the v1.7.0 release of containerd on the node.
+        # default: false
+        - name: "INSTALL_OFFICIAL_CONTAINERD"
+          value: "false"
     environmentVariables:
       - name: NODE_NAME
         valueFrom:

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -74,6 +74,11 @@ spec:
             path: /run/systemd/system
             type: ""
           name: systemd
+      environmentVariables:
+        # If set to true, this will install the CoCo fork of the containerd on the node.
+        # default: true
+        - name: "INSTALL_COCO_CONTAINERD"
+          value: "true"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -102,6 +107,11 @@ spec:
             path: /run/systemd/system
             type: ""
           name: systemd
+      environmentVariables:
+        # If set to true, this will install the CoCo fork of the containerd on the node.
+        # default: true
+        - name: "INSTALL_COCO_CONTAINERD"
+          value: "true"
     environmentVariables:
       - name: NODE_NAME
         valueFrom:

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -53,10 +53,6 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
-        - mountPath: /var/run/dbus/system_bus_socket
-          name: dbus
-        - mountPath: /run/systemd/system
-          name: systemd
       volumes:
         - hostPath:
             path: /opt/confidential-containers/
@@ -66,14 +62,6 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
-        - hostPath:
-            path: /var/run/dbus/system_bus_socket
-            type: ""
-          name: dbus
-        - hostPath:
-            path: /run/systemd/system
-            type: ""
-          name: systemd
       environmentVariables:
         # If set to true, this will install the CoCo fork of the containerd on the node.
         # default: true
@@ -86,10 +74,6 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
-        - mountPath: /var/run/dbus/system_bus_socket
-          name: dbus
-        - mountPath: /run/systemd/system
-          name: systemd
       volumes:
         - hostPath:
             path: /opt/confidential-containers/
@@ -99,14 +83,6 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
-        - hostPath:
-            path: /var/run/dbus/system_bus_socket
-            type: ""
-          name: dbus
-        - hostPath:
-            path: /run/systemd/system
-            type: ""
-          name: systemd
       environmentVariables:
         # If set to true, this will install the CoCo fork of the containerd on the node.
         # default: true

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -71,6 +71,11 @@ spec:
         # default: false
         - name: "INSTALL_OFFICIAL_CONTAINERD"
           value: "false"
+        # If set to true, this will install the CoCo fork of the containerd,
+        # the one that has patches for handling GPU / VFIO, on the node
+        # default: false
+        - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -95,6 +100,11 @@ spec:
         # If set to true, this will install the v1.7.0 release of containerd on the node.
         # default: false
         - name: "INSTALL_OFFICIAL_CONTAINERD"
+          value: "false"
+        # If set to true, this will install the CoCo fork of the containerd,
+        # the one that has patches for handling GPU / VFIO, on the node
+        # default: false
+        - name: "INSTALL_VFIO_GPU_CONTAINERD"
           value: "false"
     environmentVariables:
       - name: NODE_NAME

--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -8,13 +8,13 @@ ARG ARCH
 ARG COCO_CONTAINERD_VERSION
 
 ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
-ARG COCO_DESTINATION=${DESTINATION}/opt/confidential-containers
+ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
 
 RUN \
-	mkdir -p ${COCO_DESTINATION} && \
+	mkdir -p ${NODE_DESTINATION} && \
 	apk --no-cache add curl && \
 	curl -fOL --progress-bar https://github.com/confidential-containers/containerd/releases/download/v${COCO_CONTAINERD_VERSION}/containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz && \
-	tar xvzpf containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${COCO_DESTINATION} && \
+	tar xvzpf containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${NODE_DESTINATION} && \
 	rm containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
 
 #### kubectl
@@ -36,14 +36,14 @@ FROM base
 RUN apk --no-cache add bash
 
 ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
-ARG COCO_DESTINATION=${DESTINATION}/opt/confidential-containers
-ARG COCO_CONTAINERD_SYSTEMD_DESTINATION=${DESTINATION}/etc/systemd/system/containerd.service.d/
+ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
+ARG NODE_CONTAINERD_SYSTEMD_DESTINATION=${DESTINATION}/etc/systemd/system/containerd.service.d/
 
 ARG CONTAINERD_SYSTEMD_ARTIFACTS=./containerd/containerd-for-cc-override.conf
 
-COPY --from=coco-containerd-binary-downloader ${COCO_DESTINATION}/bin/ ${COCO_DESTINATION}/bin/
+COPY --from=coco-containerd-binary-downloader ${NODE_DESTINATION}/bin/ ${NODE_DESTINATION}/bin/
 COPY --from=kubectl-binary-downloader /usr/bin/kubectl /usr/bin/kubectl
-COPY ${CONTAINERD_SYSTEMD_ARTIFACTS} ${COCO_CONTAINERD_SYSTEMD_DESTINATION}
+COPY ${CONTAINERD_SYSTEMD_ARTIFACTS} ${NODE_CONTAINERD_SYSTEMD_DESTINATION}
 
 ARG CONTAINER_ENGINE_ARTIFACTS=./scripts
 COPY ${CONTAINER_ENGINE_ARTIFACTS}/* ${DESTINATION}/scripts/

--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -41,7 +41,7 @@ ARG NODE_CONTAINERD_SYSTEMD_DESTINATION=${DESTINATION}/etc/systemd/system/contai
 
 ARG CONTAINERD_SYSTEMD_ARTIFACTS=./containerd/containerd-for-cc-override.conf
 
-COPY --from=coco-containerd-binary-downloader ${NODE_DESTINATION}/bin/ ${NODE_DESTINATION}/bin/
+COPY --from=coco-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/coco-containerd
 COPY --from=kubectl-binary-downloader /usr/bin/kubectl /usr/bin/kubectl
 COPY ${CONTAINERD_SYSTEMD_ARTIFACTS} ${NODE_CONTAINERD_SYSTEMD_DESTINATION}
 

--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -6,6 +6,7 @@ FROM base as coco-containerd-binary-downloader
 
 ARG ARCH
 ARG COCO_CONTAINERD_VERSION
+ARG COCO_CONTAINERD_REPO
 
 ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
 ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
@@ -13,9 +14,27 @@ ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
 RUN \
 	mkdir -p ${NODE_DESTINATION} && \
 	apk --no-cache add curl && \
-	curl -fOL --progress-bar https://github.com/confidential-containers/containerd/releases/download/v${COCO_CONTAINERD_VERSION}/containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz && \
+	curl -fOL --progress-bar ${COCO_CONTAINERD_REPO}/releases/download/v${COCO_CONTAINERD_VERSION}/containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz && \
 	tar xvzpf containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${NODE_DESTINATION} && \
 	rm containerd-${COCO_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
+
+#### Official containerd
+
+FROM base as official-containerd-binary-downloader
+
+ARG ARCH
+ARG OFFICIAL_CONTAINERD_VERSION
+ARG OFFICIAL_CONTAINERD_REPO
+
+ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
+ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
+
+RUN \
+	mkdir -p ${NODE_DESTINATION} && \
+	apk --no-cache add curl && \
+	curl -fOL --progress-bar ${OFFICIAL_CONTAINERD_REPO}/releases/download/v${OFFICIAL_CONTAINERD_VERSION}/containerd-${OFFICIAL_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz && \
+	tar xvzpf containerd-${OFFICIAL_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${NODE_DESTINATION} && \
+	rm containerd-${OFFICIAL_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
 
 #### kubectl
 
@@ -42,6 +61,7 @@ ARG NODE_CONTAINERD_SYSTEMD_DESTINATION=${DESTINATION}/etc/systemd/system/contai
 ARG CONTAINERD_SYSTEMD_ARTIFACTS=./containerd/containerd-for-cc-override.conf
 
 COPY --from=coco-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/coco-containerd
+COPY --from=official-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/official-containerd
 COPY --from=kubectl-binary-downloader /usr/bin/kubectl /usr/bin/kubectl
 COPY ${CONTAINERD_SYSTEMD_ARTIFACTS} ${NODE_CONTAINERD_SYSTEMD_DESTINATION}
 

--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -36,6 +36,25 @@ RUN \
 	tar xvzpf containerd-${OFFICIAL_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${NODE_DESTINATION} && \
 	rm containerd-${OFFICIAL_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
 
+#### Confidential Containers forked containerd for VFIO / GPU stuff
+
+FROM base as vfio-gpu-containerd-binary-downloader
+
+ARG ARCH
+ARG VFIO_GPU_CONTAINERD_VERSION
+ARG VFIO_GPU_CONTAINERD_REPO
+
+ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
+ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
+
+RUN \
+	mkdir -p ${NODE_DESTINATION} && \
+	apk --no-cache add curl && \
+	curl -fOL --progress-bar ${VFIO_GPU_CONTAINERD_REPO}/releases/download/v${VFIO_GPU_CONTAINERD_VERSION}/containerd-${VFIO_GPU_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz && \
+	tar xvzpf containerd-${VFIO_GPU_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${NODE_DESTINATION} && \
+	rm containerd-${VFIO_GPU_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
+
+
 #### kubectl
 
 FROM base as kubectl-binary-downloader
@@ -62,6 +81,7 @@ ARG CONTAINERD_SYSTEMD_ARTIFACTS=./containerd/containerd-for-cc-override.conf
 
 COPY --from=coco-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/coco-containerd
 COPY --from=official-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/official-containerd
+COPY --from=vfio-gpu-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/vfio-gpu-containerd
 COPY --from=kubectl-binary-downloader /usr/bin/kubectl /usr/bin/kubectl
 COPY ${CONTAINERD_SYSTEMD_ARTIFACTS} ${NODE_CONTAINERD_SYSTEMD_DESTINATION}
 

--- a/install/pre-install-payload/Makefile
+++ b/install/pre-install-payload/Makefile
@@ -1,6 +1,6 @@
-CONTAINERD_VERSION = 1.6.8.2
+COCO_CONTAINERD_VERSION = 1.6.8.2
 
 BASH = bash
 
 reqs-image:
-	containerd_version=$(CONTAINERD_VERSION) $(BASH) -x payload.sh
+	coco_containerd_version=$(COCO_CONTAINERD_VERSION) $(BASH) -x payload.sh

--- a/install/pre-install-payload/Makefile
+++ b/install/pre-install-payload/Makefile
@@ -1,6 +1,9 @@
 COCO_CONTAINERD_VERSION = 1.6.8.2
+OFFICIAL_CONTAINERD_VERSION = 1.7.0
 
 BASH = bash
 
 reqs-image:
-	coco_containerd_version=$(COCO_CONTAINERD_VERSION) $(BASH) -x payload.sh
+	coco_containerd_version=$(COCO_CONTAINERD_VERSION) \
+	official_containerd_version=$(OFFICIAL_CONTAINERD_VERSION) \
+	$(BASH) -x payload.sh

--- a/install/pre-install-payload/Makefile
+++ b/install/pre-install-payload/Makefile
@@ -1,9 +1,11 @@
 COCO_CONTAINERD_VERSION = 1.6.8.2
 OFFICIAL_CONTAINERD_VERSION = 1.7.0
+VFIO_GPU_CONTAINERD_VERSION = 1.7.0.0
 
 BASH = bash
 
 reqs-image:
 	coco_containerd_version=$(COCO_CONTAINERD_VERSION) \
 	official_containerd_version=$(OFFICIAL_CONTAINERD_VERSION) \
+	vfio_gpu_containerd_version=$(VFIO_GPU_CONTAINERD_VERSION) \
 	$(BASH) -x payload.sh

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -8,6 +8,8 @@ script_dir=$(dirname "$(readlink -f "$0")")
 
 coco_containerd_repo=${coco_containerd_repo:-"https://github.com/confidential-containers/containerd"}
 coco_containerd_version=${coco_containerd_version:-"v1.6.6.0"}
+official_containerd_repo=${official_containerd_repo:-"https://github.com/containerd/containerd"}
+official_containerd_version=${official_containerd_version:-"1.7.0"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
 extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
 
@@ -57,6 +59,9 @@ function build_payload() {
 		docker buildx build \
 			--build-arg ARCH="${golang_arch}" \
 			--build-arg COCO_CONTAINERD_VERSION="${coco_containerd_version}" \
+			--build-arg COCO_CONTAINERD_REPO="${coco_containerd_repo}" \
+			--build-arg OFFICIAL_CONTAINERD_VERSION="${official_containerd_version}" \
+			--build-arg OFFICIAL_CONTAINERD_REPO="${official_containerd_repo}" \
 			-t "${registry}:${kernel_arch}-${tag}" \
 			--platform="${arch}" \
 			--load \

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -6,8 +6,8 @@ set -o nounset
 
 script_dir=$(dirname "$(readlink -f "$0")")
 
-containerd_repo=${containerd_repo:-"https://github.com/confidential-containers/containerd"}
-containerd_version=${containerd_version:-"v1.6.6.0"}
+coco_containerd_repo=${coco_containerd_repo:-"https://github.com/confidential-containers/containerd"}
+coco_containerd_version=${coco_containerd_version:-"v1.6.6.0"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
 extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
 
@@ -56,7 +56,7 @@ function build_payload() {
 		echo "Building containerd payload image for ${arch}"
 		docker buildx build \
 			--build-arg ARCH="${golang_arch}" \
-			--build-arg COCO_CONTAINERD_VERSION="${containerd_version}" \
+			--build-arg COCO_CONTAINERD_VERSION="${coco_containerd_version}" \
 			-t "${registry}:${kernel_arch}-${tag}" \
 			--platform="${arch}" \
 			--load \

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -7,7 +7,7 @@ set -o nounset
 script_dir=$(dirname "$(readlink -f "$0")")
 
 coco_containerd_repo=${coco_containerd_repo:-"https://github.com/confidential-containers/containerd"}
-coco_containerd_version=${coco_containerd_version:-"v1.6.6.0"}
+coco_containerd_version=${coco_containerd_version:-"1.6.8.2"}
 official_containerd_repo=${official_containerd_repo:-"https://github.com/containerd/containerd"}
 official_containerd_version=${official_containerd_version:-"1.7.0"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -10,6 +10,8 @@ coco_containerd_repo=${coco_containerd_repo:-"https://github.com/confidential-co
 coco_containerd_version=${coco_containerd_version:-"1.6.8.2"}
 official_containerd_repo=${official_containerd_repo:-"https://github.com/containerd/containerd"}
 official_containerd_version=${official_containerd_version:-"1.7.0"}
+vfio_gpu_containerd_repo=${vfio_gpu_containerd_repo:-"https://github.com/confidential-containers/containerd"}
+vfio_gpu_containerd_version=${vfio_gpu_containerd_version:-"1.7.0.0"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
 extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
 
@@ -62,6 +64,8 @@ function build_payload() {
 			--build-arg COCO_CONTAINERD_REPO="${coco_containerd_repo}" \
 			--build-arg OFFICIAL_CONTAINERD_VERSION="${official_containerd_version}" \
 			--build-arg OFFICIAL_CONTAINERD_REPO="${official_containerd_repo}" \
+			--build-arg VFIO_GPU_CONTAINERD_VERSION="${vfio_gpu_containerd_version}" \
+			--build-arg VFIO_GPU_CONTAINERD_REPO="${vfio_gpu_containerd_repo}" \
 			-t "${registry}:${kernel_arch}-${tag}" \
 			--platform="${arch}" \
 			--load \

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -49,6 +49,10 @@ function install_official_containerd_artefacts() {
 	install_containerd_artefacts "official"
 }
 
+function install_vfio_gpu_containerd_artefacts() {
+	install_containerd_artefacts "vfio-gpu"
+}
+
 function install_artifacts() {
 	if [ "${INSTALL_COCO_CONTAINERD}" = "true" ]; then
 		install_coco_containerd_artefacts
@@ -56,6 +60,10 @@ function install_artifacts() {
 
 	if [ "${INSTALL_OFFICIAL_CONTAINERD}" = "true" ]; then
 		install_coco_containerd_artefacts
+	fi
+
+	if [ "${INSTALL_VFIO_GPU_CONTAINERD}" = "true" ]; then
+		install_vfio_gpu_containerd_artefacts
 	fi
 }
 
@@ -80,7 +88,7 @@ function uninstall_containerd_artefacts() {
 }
 
 function uninstall_artifacts() {
-	if [ "${INSTALL_COCO_CONTAINERD}" = "true" ] || [ "${INSTALL_OFFICIAL_CONTAINERD}" = "true" ]; then
+	if [ "${INSTALL_COCO_CONTAINERD}" = "true" ] || [ "${INSTALL_OFFICIAL_CONTAINERD}" = "true" ] || [ "${INSTALL_VFIO_GPU_CONTAINERD}" = "true" ]; then
 		uninstall_containerd_artefacts
 	fi
 }
@@ -111,6 +119,7 @@ function print_help() {
 function main() {
 	echo "INSTALL_COCO_CONTAINERD: ${INSTALL_COCO_CONTAINERD}"
 	echo "INSTALL_OFFICIAL_CONTAINERD: ${INSTALL_OFFICIAL_CONTAINERD}"
+	echo "INSTALL_VFIO_GPU_CONTAINERD: ${INSTALL_VFIO_GPU_CONTAINERD}"
 
 	# script requires that user is root
 	local euid=$(id -u)

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -45,8 +45,16 @@ function install_coco_containerd_artefacts() {
 	install_containerd_artefacts "coco"
 }
 
+function install_official_containerd_artefacts() {
+	install_containerd_artefacts "official"
+}
+
 function install_artifacts() {
 	if [ "${INSTALL_COCO_CONTAINERD}" = "true" ]; then
+		install_coco_containerd_artefacts
+	fi
+
+	if [ "${INSTALL_OFFICIAL_CONTAINERD}" = "true" ]; then
 		install_coco_containerd_artefacts
 	fi
 }
@@ -72,7 +80,7 @@ function uninstall_containerd_artefacts() {
 }
 
 function uninstall_artifacts() {
-	if [ "${INSTALL_COCO_CONTAINERD}" = "true" ]; then
+	if [ "${INSTALL_COCO_CONTAINERD}" = "true" ] || [ "${INSTALL_OFFICIAL_CONTAINERD}" = "true" ]; then
 		uninstall_containerd_artefacts
 	fi
 }
@@ -102,6 +110,7 @@ function print_help() {
 
 function main() {
 	echo "INSTALL_COCO_CONTAINERD: ${INSTALL_COCO_CONTAINERD}"
+	echo "INSTALL_OFFICIAL_CONTAINERD: ${INSTALL_OFFICIAL_CONTAINERD}"
 
 	# script requires that user is root
 	local euid=$(id -u)


### PR DESCRIPTION
This work is required as we'll move out from the forked version of containerd, but not for all the projects, and not without requiring a minimum version of containerd to do so.

As enclave-cc will still be depending on the containerd fork for v0.8.0, and as we may need to still install the minimum version of containerd on clusters using, for a reason or another, containerd v1.6.x, we need to handle those two different installations in a graceful manner.