### PR TITLE
Fix `panic: odd number of arguments passed as key-value pairs for logging`

### DIFF
--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -470,7 +470,7 @@ func (r *CcRuntimeReconciler) monitorCcRuntimeInstallation() (ctrl.Result, error
 			foundRc := &nodeapi.RuntimeClass{}
 			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: runtimeClass.Name}, foundRc)
 			if errors.IsNotFound(err) {
-				r.Log.Info("The runtime payload failed to create the runtime class named %s", runtimeClass.Name)
+				r.Log.Info("The runtime payload failed to create the runtime class", "runtimeClassName", runtimeClass.Name)
 				return ctrl.Result{}, err
 			}
 			runtimeClassNames = append(runtimeClassNames, runtimeClass.Name)


### PR DESCRIPTION

```
panic: odd number of arguments passed as key-value pairs for logging [recovered]
        panic: odd number of arguments passed as key-value pairs for logging
...
github.com/confidential-containers/operator/controllers.(*CcRuntimeReconciler).monitorCcRuntimeInstallation(0xc0002d4190)
        /workspace/controllers/ccruntime_controller.go:473 +0x3bf
```