### PR TITLE
enclave-cc: fix HW kustomization

### DIFF
--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
 
 nameSuffix: -sgx-mode-hw
 
+images:
 - name: quay.io/confidential-containers/reqs-payload
   newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f


### PR DESCRIPTION
The 'images' key was missing and resulted in

error: invalid Kustomization: yaml: line 8: did not find expected key