### PR TITLE
tests/e2e: describe all pods on teardown

### DIFF
--- a/tests/e2e/operator_tests.bats
+++ b/tests/e2e/operator_tests.bats
@@ -44,4 +44,7 @@ systemctl is-active "$container_runtime"
 teardown() {
 	# For debugging sake.
 	kubectl get pods -A || true
+	echo "::group::Describe all pods of confidential-containers namespace"
+	kubectl -n confidential-containers describe pods || true
+	echo "::endgroup::"
 }


### PR DESCRIPTION
On operator_tests.bats's teardown let's print the description of all pods in the confidential-containers namespace to help on debug fails.