### PR TITLE
config: Use the latest pre-reqs payload

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
+  newTag: latest
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-latest

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
+  newTag: latest
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-latest

--- a/config/samples/ccruntime/ssh-demo/kustomization.yaml
+++ b/config/samples/ccruntime/ssh-demo/kustomization.yaml
@@ -10,7 +10,7 @@ images:
 - name: quay.io/confidential-containers/runtime-payload
   newTag: kata-containers-ssh-demo-v0.2.0
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
+  newTag: latest
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -8,4 +8,4 @@ nameSuffix: -sgx-mode-hw
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
+  newTag: latest

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -7,4 +7,4 @@ images:
 - name: quay.io/confidential-containers/runtime-payload-ci
   newTag: enclave-cc-SIM-sample-kbc-latest
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e45d4e84c3ce4ae116f3f4d6c123c4829606026f
+  newTag: latest


### PR DESCRIPTION
After the release we should have changed those to be using the `:latest`, as we do with the kata-containers / enclave-cc payloads.