### PR TITLE
pre-install: Create containerd config it it doesn't exist

### DIFF
--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -149,10 +149,6 @@ function restart_systemd_service() {
 function configure_nydus_snapshotter_for_containerd() {
 	echo "configure nydus snapshotter for containerd"
 
-	if [ ! -f "$containerd_config" ]; then
-		die "failed to find containerd config"
-	fi
-
 	containerd_imports_path="/etc/containerd/config.toml.d"
 
 	echo "Create ${containerd_imports_path}"
@@ -219,6 +215,12 @@ function main() {
 	local action=${1:-}
 	if [ -z "${action}" ]; then
 		print_help && die ""
+	fi
+
+
+	if [ ! -f "${containerd_config}" ]; then
+		mkdir -p /etc/containerd
+		containerd config default > /etc/containerd/config.toml
 	fi
 
 	set_container_engine


### PR DESCRIPTION
We're relying here on containerd being on /usr/local/bin/, which we do have access to, in order to create such config.

We're creating the config as the first thing on the script, as we don't want to get into the situation where a configuration was added / removed and we end up with that in the system due to us using a newer version of containerd than the one present in the system.

We may face more issues in the future, such as:
* containerd is only in /usr/bin/
  * We can start exposing this as a host path mount, but let's not do it unless it becomes necessary
* when CRI-O is supported, this file should only be created in case containerd is used

However, for now, let's go with this approach and avoid users hitting a possible error due to the lack of contained configuration.

Fixes: #271