### PR TITLE
pre-install: pre-install: Remove nydus-snapshotter config

### DIFF
--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -116,6 +116,3 @@ COPY ${NYDUS_SNAPSHOTTER_ARTIFACTS} ${NODE_DESTINATION}/share/nydus-snapshotter/
 
 ARG CONTAINER_ENGINE_ARTIFACTS=./scripts
 COPY ${CONTAINER_ENGINE_ARTIFACTS}/* ${DESTINATION}/scripts/
-
-# Also copy `ctr` to our final image, so we can use it to remove nydus snapshots
-COPY --from=official-containerd-binary-downloader ${NODE_DESTINATION}/bin/ctr /usr/bin/ctr

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -126,7 +126,12 @@ function uninstall_nydus_snapshotter_artefacts() {
 	rm -f /opt/confidential-containers/bin/containerd-nydus-grpc
 	rm -f /opt/confidential-containers/bin/nydus-overlayfs
 	rm -f /usr/local/bin/nydus-overlayfs
-	rm -f /opt/confidential-containers/share/remote-snapshotter/config-coco-guest-pulling.toml
+	rm -f /opt/confidential-containers/share/nydus-snapshotter/config-coco-guest-pulling.toml
+
+	# We can do this here as we're sure that only the nydus-snapshotter is
+	# installing something in the /opt/confidential-containers/share
+	# directory
+	rm -rf /opt/confidential-containers/share
 	rm -rf /var/lib/containerd-nydus/*
 }	
 

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -13,6 +13,10 @@ die() {
 	exit 1
 }
 
+function host_ctr() {
+	nsenter --target 1 --mount ctr "${@}"
+}
+
 function host_systemctl() {
 	nsenter --target 1 --mount systemctl "${@}"
 }
@@ -112,8 +116,8 @@ function uninstall_containerd_artefacts() {
 
 function uninstall_nydus_snapshotter_artefacts() {
 	if host_systemctl list-units | grep -q nydus-snapshotter; then
-		for i in `ctr -n k8s.io snapshot --snapshotter nydus list | grep -v KEY | cut -d' ' -f1`; do
-			ctr -n k8s.io snapshot --snapshotter nydus rm $i || true
+		for i in `host_ctr -n k8s.io snapshot --snapshotter nydus list | grep -v KEY | cut -d' ' -f1`; do
+			host_ctr -n k8s.io snapshot --snapshotter nydus rm $i || true
 		done
 
 		remove_nydus_snapshotter_from_containerd

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -112,6 +112,10 @@ function uninstall_containerd_artefacts() {
 
 function uninstall_nydus_snapshotter_artefacts() {
 	if host_systemctl list-units | grep -q nydus-snapshotter; then
+		for i in `ctr -n k8s.io snapshot --snapshotter nydus list | grep -v KEY | cut -d' ' -f1`; do
+			ctr -n k8s.io snapshot --snapshotter nydus rm $i || true
+		done
+
 		remove_nydus_snapshotter_from_containerd
 		host_systemctl disable --now nydus-snapshotter.service
 		rm -rf /etc/systemd/system/nydus-snapshotter.service
@@ -120,9 +124,6 @@ function uninstall_nydus_snapshotter_artefacts() {
 	fi
 
 	echo "Removing nydus-snapshotter artifacts from host"
-	for i in `ctr -n k8s.io snapshot --snapshotter nydus list | grep -v KEY | cut -d' ' -f1`; do
-		ctr -n k8s.io snapshot --snapshotter nydus rm $i || true
-	done
 	rm -f /opt/confidential-containers/bin/containerd-nydus-grpc
 	rm -f /opt/confidential-containers/bin/nydus-overlayfs
 	rm -f /usr/local/bin/nydus-overlayfs


### PR DESCRIPTION
We've been leaving the nydus-snapshotter config behind because we were
trying to remove it from a path that was changed from the first
iteration of the nydus-snapshotter addition, but ended up not being
noticed during review.

While here, let's also make sure to entirely remove
`/opt/confidential-containers/share`, as nydus-snapshotter is the only
bit of code using that.

Fixes: #278

While here let's also pre-remove ctr cleanup of nydus snapshotters

This has proven to be useless as it is, as `ctr` doesn't have access to
the `/var/run/{containerd,containerd-nydus}` to actually be able to
perform any operation.

We could, obviously, expose those to the operator, but I'm very much
against adding even more host mounts to the operator, unless this is
strictly needed, and right now I don't think it is (and I'm fine to be
proven wrong in the future ;-)).

