### PR TITLE
config: update operator payloads for v0.8.0 release

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: fad6ef4607e929c2d30d16dc8c62fbb29881a44c
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-424de1cbfa4e1da9ecf9a56b1d1e1a11a4f339cd
+  newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: fad6ef4607e929c2d30d16dc8c62fbb29881a44c
+  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: latest
+  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: latest
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-424de1cbfa4e1da9ecf9a56b1d1e1a11a4f339cd
+  newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 images:
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-latest
+  newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-b58c59dc72a0b10ae3dd4436a206fd54a820c9f7
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-ed979ef2952d8b20c2f0abee3d32a3617d2c57bb
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -8,4 +8,4 @@ nameSuffix: -sgx-mode-hw
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: fad6ef4607e929c2d30d16dc8c62fbb29881a44c
+  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -7,4 +7,4 @@ images:
 - name: quay.io/confidential-containers/runtime-payload-ci
   newTag: enclave-cc-SIM-sample-kbc-ed979ef2952d8b20c2f0abee3d32a3617d2c57bb
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: fad6ef4607e929c2d30d16dc8c62fbb29881a44c
+  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -5,6 +5,6 @@ nameSuffix: -sgx-mode-sim
 
 images:
 - name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-sample-kbc-b58c59dc72a0b10ae3dd4436a206fd54a820c9f7
+  newTag: enclave-cc-SIM-sample-kbc-ed979ef2952d8b20c2f0abee3d32a3617d2c57bb
 - name: quay.io/confidential-containers/reqs-payload
   newTag: fad6ef4607e929c2d30d16dc8c62fbb29881a44c

--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -66,7 +66,7 @@ build_pre_install_img() {
 handle_older_containerd() {
         command -v containerd >/dev/null || return
         local version
-        version=$(containerd -v | awk '{ print $3 }')
+        version=$(containerd -v | awk '{ print $3 }' | sed 's/^v//')
         echo "system's containerd version: $version"
         if [[ "$version" =~ ^1.6 || "$version" =~ ^1.5 ]]; then
                 echo "Old system's containerd ($version). Configuring the operator to install a newer one"


### PR DESCRIPTION
This covers step 13 from the release checklist [here](https://github.com/confidential-containers/confidential-containers/issues/145)