### PR TITLE
config: update operator to use release tags for enclave-cc and kata

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2
+  newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2
+  newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 images:
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-4089d48b4532139e361af8f3b84d97d25f57d9c2
+  newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-ed979ef2952d8b20c2f0abee3d32a3617d2c57bb
+    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-cc-kbc-v0.8.0
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-sample-kbc-ed979ef2952d8b20c2f0abee3d32a3617d2c57bb
+- name: quay.io/confidential-containers/runtime-payload
+  newTag: enclave-cc-SIM-sample-kbc-v0.8.0
 - name: quay.io/confidential-containers/reqs-payload
   newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023


### PR DESCRIPTION
This covers step 19 from the release checklist [here](https://github.com/confidential-containers/confidential-containers/issues/145)