### PR TITLE
config: set reqs-payload for v0.8.0 release

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
+  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
+  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
 - name: quay.io/confidential-containers/runtime-payload
   newName: quay.io/confidential-containers/runtime-payload-ci
   newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -8,4 +8,4 @@ nameSuffix: -sgx-mode-hw
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
+  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -7,4 +7,4 @@ images:
 - name: quay.io/confidential-containers/runtime-payload
   newTag: enclave-cc-SIM-sample-kbc-v0.8.0
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: c31205eb31d8a4623ffc0c9fa316e3c91e337023
+  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a


### PR DESCRIPTION
This was waiting on the merge from [PR 284](https://github.com/confidential-containers/operator/pull/284), which is now done. This grabs the corresponding reqs-payload hash and sets the operator to point to that bundle.