### PR TITLE
actions: build the bundle on pull requests

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -31,3 +31,6 @@ jobs:
 
     - name: Build controller
       run: make build
+
+    - name: Build bundle
+      run: make bundle IMG=quay.io/confidential-containers/operator:latest


### PR DESCRIPTION
So we check the bundle is not broken way before we try to publish it on the Operator Hub.