### PR TITLE
tests/e2e: Migrate e2e test for s390x to GHA

### DIFF
--- a/.github/workflows/ccruntime-nightly.yaml
+++ b/.github/workflows/ccruntime-nightly.yaml
@@ -1,0 +1,24 @@
+name: ccruntime e2e test nightly
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  e2e-nightly:
+    uses: ./.github/workflows/ccruntime_e2e.yaml
+
+  e2e-ibm-se-nightly:
+    runs-on: s390x
+    strategy:
+      fail-fast: false
+      matrix:
+        test_title:
+          - cc-operator-e2e-tests
+    steps:
+    - name: Fetch a test result for {{ matrix.test_title }}
+      run: |
+        file_name="${TEST_TITLE}-$(date +%Y-%m-%d).log"
+        /home/${USER}/script/handle_test_log.sh download $file_name
+      env:
+        TEST_TITLE: ${{ matrix.test_title }}

--- a/.github/workflows/ccruntime-pr.yaml
+++ b/.github/workflows/ccruntime-pr.yaml
@@ -1,0 +1,19 @@
+name: ccruntime e2e test for PR
+on:
+  pull_request_target:
+    branches:
+      - 'main'
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  e2e-pr:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    uses: ./.github/workflows/ccruntime_e2e.yaml
+    with:
+      target-branch: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -1,8 +1,11 @@
 name: ccruntime e2e tests
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      target-branch:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -13,11 +16,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtimeclass: ["kata-qemu", "kata-clh"]
-        instance: ["az-ubuntu-2004", "az-ubuntu-2204"]
+        runtimeclass:
+          - "kata-qemu"
+          - "kata-clh"
+        instance:
+          - "az-ubuntu-2004"
+          - "az-ubuntu-2204"
+          - "s390x"
+        exclude:
+          - runtimeclass: "kata-clh"
+            instance: "s390x"
     runs-on: ${{ matrix.instance }}
     steps:
+      - name: Take a pre-action for self-hosted runner
+        run: |
+          if [ -f ${HOME}/script/pre_action.sh ]; then
+            ${HOME}/script/pre_action.sh cc-operator
+          fi
+
       - uses: actions/checkout@v4
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install deps
         run: |
@@ -29,4 +52,17 @@ jobs:
         run: |
           cd tests/e2e
           export PATH="$PATH:/usr/local/bin"
-          ./run-local.sh -r "${{ matrix.runtimeclass }}" -u
+          args="-u"
+          if [ $RUNNING_INSTANCE = "s390x" ]; then
+            args=""
+          fi
+          ./run-local.sh -r "${{ matrix.runtimeclass }}" "${args}"
+        env:
+          RUNNING_INSTANCE: ${{ matrix.instance }}
+
+      - name: Take a post-action
+        if: always()
+        run: |
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh cc-operator
+          fi

--- a/tests/e2e/ansible/install_docker.yml
+++ b/tests/e2e/ansible/install_docker.yml
@@ -77,6 +77,43 @@
           - docker-ce-cli
         state: present
   when: docker_exist.rc != 0 and ansible_distribution == "CentOS"
+#
+# In order to prevent "systemd: docker.service Start request repeated too quickly"
+#
+- name: Set StartLimitBurst to 0 on Ubuntu for s390x
+  block:
+    - name: If a fragment path starts with `/lib`, then create /etc/systemd/system/docker.service.d
+      block:
+        - name: Get FragmentPath
+          shell: systemctl show -p FragmentPath docker.service | awk -F'=' '{print $2}'
+          register: fragment_path
+        - name: Copy fragment file to /etc/systemd/system/docker.service.d
+          copy:
+            src: "{{ fragment_path.stdout }}"
+            dest: "{{ fragment_path.stdout.replace('/lib', '/etc') }}"
+          when: fragment_path.stdout.find('/lib') != -1
+    - name: Configure `StartLimitBurst=0` in /etc/systemd/system/docker.service
+      block:
+        - name: Check if /etc/systemd/system/docker.service has StartLimitBurst=0
+          shell: grep -q 'StartLimitBurst' /etc/systemd/system/docker.service
+          register: start_limit_burst
+          ignore_errors: yes
+        - name: Replace a value of StartLimitBurst to 0
+          lineinfile:
+            path: /etc/systemd/system/docker.service
+            regexp: '^StartLimitBurst='
+            line: 'StartLimitBurst=0'
+          when: start_limit_burst.rc == 0
+        - name: Otherwise, insert `StartLimitBurst=0` just after a service section
+          lineinfile:
+            path: /etc/systemd/system/docker.service
+            insertafter: '\[Service\]'
+            line: 'StartLimitBurst=0'
+          when: start_limit_burst.rc != 0
+    - name: Reload systemd
+      systemd:
+        daemon_reload: yes
+  when: ansible_distribution == "Ubuntu" and ansible_architecture == 's390x'
 - name: Start docker service
   service:
     name: docker

--- a/tests/git-helper.sh
+++ b/tests/git-helper.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Copyright Confidential Containers Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function install_jq() {
+	if [ -n "$(command -v apt-get)" ]; then
+		sudo apt-get update
+		sudo apt-get install -y jq
+	elif [ -n "$(command -v yum)" ]; then
+		sudo yum install -y epel-release
+		sudo yum install -y jq
+	else
+		>&2 echo "No supported package manager found"
+		exit 1
+	fi
+}
+
+function configure_github() {
+	if [ ! command -v jq &> /dev/null ]; then
+		echo "jq is not installed, installing it"
+		install_jq
+	fi
+	USERNAME=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
+	EMAIL=$(jq -r '.pull_request.user.email' "$GITHUB_EVENT_PATH")
+	# if the email is null, stuff with a dummy email
+	if [ "${EMAIL}" == "null" ]; then
+		EMAIL="dummy@email.address"
+	fi
+	echo "Adding user name ${USERNAME} and email ${EMAIL} to the local git repo"
+	git config user.name "${USERNAME}"
+	git config user.email "${EMAIL}"
+}
+
+function rebase_atop_of_the_latest_target_branch() {
+	if [ -n "${TARGET_BRANCH}" ]; then
+		configure_github
+		echo "Rebasing atop of the latest ${TARGET_BRANCH}"
+		# Recover from any previous rebase left halfway
+		git rebase --abort 2> /dev/null || true
+		if ! git rebase origin/${TARGET_BRANCH}; then
+			>&2 echo "Rebase failed, exiting"
+			exit 1
+		fi
+	fi
+}
+
+function main() {
+	action="${1:-}"
+
+	case "${action}" in
+	rebase-atop-of-the-latest-target-branch) rebase_atop_of_the_latest_target_branch;;
+	*) >&2 echo "Invalid argument"; exit 2 ;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
This PR is to migrate the following e2e tests for s390x in Jenkins to GHA:

- confidential-containers-operator-main-ubuntu-20.04-s390x-containerd_kata-qemu-baseline
- confidential-containers-operator-main-ubuntu-20.04-s390x-containerd_kata-qemu-PR
- confidential-containers-operator-main-ubuntu-20.04-s390x-SE-daily

It will be staying in a `work-in-progress` state and the workflow structure will be changed based on that of `x86_64`. (i.e. a decision could be made when https://github.com/confidential-containers/operator/pull/260 is finalised.)

The workflow itself has been tested several times

- https://github.com/BbolroC/cc-operator/actions/runs/7017907526
- https://github.com/BbolroC/cc-operator/actions/runs/7017396678
- https://github.com/BbolroC/cc-operator/actions/runs/7011926398

The rationale for the `{pre,post}` action in the workflow is as follows:

1. A self-hosted runner for s390x cannot be instantiated and used instantly on request, rather should be ready/running 24/7. It is inevitable to institute a hook for the management over test runs.
2. The management script could be committed to the repo, but it wouldn't be flexible enough to tackle any environmental issues on the runner.

Of course, an introduction of the actions makes it hard to incorporate workflows for different architectures into one via `matrix` because `if:` for the selective run for an architecture (e.g. `if: ${{ matrix.arch == 's390x' }}`) conflicts with `if: always()` which is used for the post action. I look forward to any feedback for those two actions.

There are 2 things which must be prepared before the merge:

1. Registration for a self-hosted runner for s390x
2. Configuration of a secret named `REGISTRY_CREDENTIAL_ENCODED`.

Thanks.

Fixes: #294

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>