### PR TITLE
Kata main payload

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -85,7 +85,7 @@ metadata:
                   "name": "local-bin"
                 }
               ],
-              "payloadImage": "quay.io/confidential-containers/runtime-payload-ci:kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1",
+              "payloadImage": "quay.io/kata-containers/kata-deploy-ci:kata-containers-latest",
               "postUninstall": {
                 "image": "quay.io/confidential-containers/reqs-payload:e92cb67ea8956128a31950a0c3fa79a086dbaf1a",
                 "volumeMounts": [

--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -87,7 +87,7 @@ metadata:
               ],
               "payloadImage": "quay.io/kata-containers/kata-deploy-ci:kata-containers-latest",
               "postUninstall": {
-                "image": "quay.io/confidential-containers/reqs-payload:e92cb67ea8956128a31950a0c3fa79a086dbaf1a",
+                "image": "quay.io/confidential-containers/reqs-payload:latest",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",
@@ -149,7 +149,7 @@ metadata:
                 ]
               },
               "preInstall": {
-                "image": "quay.io/confidential-containers/reqs-payload:e92cb67ea8956128a31950a0c3fa79a086dbaf1a",
+                "image": "quay.io/confidential-containers/reqs-payload:latest",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",

--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -216,10 +216,6 @@ metadata:
                   "snapshotter": "nydus"
                 },
                 {
-                  "name": "kata-clh-tdx",
-                  "snapshotter": "nydus"
-                },
-                {
                   "name": "kata-qemu",
                   "snapshotter": "nydus"
                 },
@@ -250,8 +246,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Security
-    containerImage: quay.io/confidential-containers/operator:v0.8.0
-    createdAt: "2023-11-15T15:02:03Z"
+    containerImage: quay.io/confidential-containers/operator:latest
+    createdAt: "2023-11-30T13:53:32Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: cc-operator.v0.8.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/confidential-containers/operator
-  newTag: v0.8.0
+  newTag: latest

--- a/config/manifests/bases/cc-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cc-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Security
-    containerImage: quay.io/confidential-containers/operator:v0.8.0
+    containerImage: quay.io/confidential-containers/operator:latest
   name: cc-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -10,7 +10,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:kata-containers
+    payloadImage: quay.io/kata-containers/kata-deploy:stable
     installDoneLabel:
       katacontainers.io/kata-runtime: "true"
     uninstallDoneLabel:
@@ -146,4 +146,3 @@ spec:
       # default: false
       - name: "INSTALL_NYDUS_SNAPSHOTTER"
         value: "true"
-

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
+  newTag: latest
 - name: quay.io/kata-containers/kata-deploy
   newName: quay.io/kata-containers/kata-deploy-ci
   newTag: kata-containers-latest

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -20,8 +20,6 @@ patches:
       value:
       - name: "kata-clh"
         snapshotter: "nydus"
-      - name: "kata-clh-tdx"
-        snapshotter: "nydus"
       - name: "kata-qemu"
         snapshotter: "nydus"
       - name: "kata-qemu-tdx"

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
 images:
 - name: quay.io/confidential-containers/reqs-payload
   newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
-- name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1
+- name: quay.io/kata-containers/kata-deploy
+  newName: quay.io/kata-containers/kata-deploy-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
+  newTag: latest
 - name: quay.io/kata-containers/kata-deploy
   newName: quay.io/kata-containers/kata-deploy-ci
   newTag: kata-containers-latest

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -9,9 +9,10 @@ resources:
 images:
 - name: quay.io/confidential-containers/reqs-payload
   newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
-- name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1
+- name: quay.io/kata-containers/kata-deploy
+  newName: quay.io/kata-containers/kata-deploy-ci
+  newTag: kata-containers-latest
+
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -18,8 +18,6 @@ patches:
       value:
       - name: "kata-qemu"
         snapshotter: "nydus"
-      - name: "kata-qemu-se"
-        snapshotter: "nydus"
     - op: add
       path: /spec/config/defaultRuntimeClassName
       value: "kata-qemu"

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -7,9 +7,9 @@ resources:
 - ../default
 
 images:
-- name: quay.io/confidential-containers/runtime-payload
-  newName: quay.io/confidential-containers/runtime-payload-ci
-  newTag: kata-containers-8de1f8e19f858134ba455a7c04edcb21d8bcf6b1
+- name: quay.io/kata-containers/kata-deploy
+  newName: quay.io/kata-containers/kata-deploy-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -8,4 +8,4 @@ nameSuffix: -sgx-mode-hw
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
+  newTag: latest

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -7,4 +7,4 @@ images:
 - name: quay.io/confidential-containers/runtime-payload
   newTag: enclave-cc-SIM-sample-kbc-v0.8.0
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e92cb67ea8956128a31950a0c3fa79a086dbaf1a
+  newTag: latest

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -147,7 +147,7 @@ as shown below, where `<MY_CUSTOM_CR>`, `<MY_PAYLOAD>`, and `<TAG>` needs to be 
 make kustomize
 cp -r config/samples/ccruntime/default config/samples/ccruntime/<MY_CUSTOM_CR>
 cd config/samples/ccruntime/<MY_CUSTOM_CR>
-../../../../bin/kustomize edit set image quay.io/confidential-containers/runtime-payload=<MY_PAYLOAD>:<TAG>
+../../../../bin/kustomize edit set image quay.io/kata-containers/kata-deploy=<MY_PAYLOAD>:<TAG>
 ```
 
 Then install the new CR as:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -131,7 +131,6 @@ A successful install should show the following `RuntimeClasses`.
 NAME            HANDLER         AGE
 kata            kata            9m55s
 kata-clh        kata-clh        9m55s
-kata-clh-tdx    kata-clh-tdx    9m55s
 kata-qemu       kata-qemu       9m55s
 kata-qemu-tdx   kata-qemu-tdx   9m55s
 kata-qemu-sev   kata-qemu-sev   9m55s

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -44,7 +44,7 @@ main() {
 
 	# Run tests.
 	case $runtimeclass in
-		kata-qemu|kata-clh|kata-qemu-se|kata-qemu-tdx|kata-qemu-sev|kata-qemu-snp)
+		kata-qemu|kata-clh|kata-qemu-tdx|kata-qemu-sev|kata-qemu-snp)
 			echo "INFO: Running operator tests for $runtimeclass"
 			bats "${script_dir}/operator_tests.bats"
 			;;

--- a/tests/e2e/tests_runner.sh
+++ b/tests/e2e/tests_runner.sh
@@ -44,7 +44,7 @@ main() {
 
 	# Run tests.
 	case $runtimeclass in
-		kata-qemu|kata-clh|kata-clh-tdx|kata-qemu-se|kata-qemu-tdx|kata-qemu-sev|kata-qemu-snp)
+		kata-qemu|kata-clh|kata-qemu-se|kata-qemu-tdx|kata-qemu-sev|kata-qemu-snp)
 			echo "INFO: Running operator tests for $runtimeclass"
 			bats "${script_dir}/operator_tests.bats"
 			;;


### PR DESCRIPTION
- Switch the `CCv0` payload to the kata-deploy main version
  - Note: I've not replaced the enclave-cc payloads as they are created in a different way IIUC
- Update operator and reqs-payload images to use latest tags