### PR TITLE
do-not-merge: Test with the pending PR from kata containers

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 - name: quay.io/confidential-containers/reqs-payload
   newTag: latest
 - name: quay.io/kata-containers/kata-deploy
-  newName: quay.io/kata-containers/kata-deploy-ci
-  newTag: kata-containers-latest
+  newName: ghcr.io/kata-containers/kata-deploy-ci
+  newTag: 8733-6ee7fb5402d426ee26905918c0f569efd2c173a6-amd64
 
 patches:
 - patch: |-


### PR DESCRIPTION
This PR has been opened in order to test the changes needed for
configuring containerd snapshotters per runtime handlers, and depends on
a PR that's not yet merged on Kata Containers:
https://github.com/kata-containers/kata-containers/pull/8733
