### PR TITLE
gha: ccruntime_e2e: Do **NOT** fail fast and add a timeout for the test execution

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -11,6 +11,7 @@ jobs:
   e2e:
     name: operator tests
     strategy:
+      fail-fast: false
       matrix:
         runtimeclass: ["kata-qemu", "kata-clh"]
         instance: ["az-ubuntu-2004", "az-ubuntu-2204"]

--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -25,6 +25,7 @@ jobs:
           sudo apt-get install -y ansible python-is-python3
 
       - name: Run e2e tests
+        timeout-minutes: 45
         run: |
           cd tests/e2e
           export PATH="$PATH:/usr/local/bin"


### PR DESCRIPTION
---

gha: ccruntime_e2e: Avoid fail-fast

Every now and then we'll face errors that may be different depending on
the distro being used, due to some distro changes or even some flakiness
in the tests.

Till everything is 100% stable, which is not the case yet, we better
allow the tests to finish even if one test fails, giving us a better
idea of the problem being a generic one or specific to flakiness / one
distro.

---

gha: ccruntime_e2e: Add a 30 minutes timeout

Today I've faced one test hanging for more than one hour, stuck, without
giving us any useful information, leaving the "cancel" option (which is
up to the user to do) as the only option to finish the test and re-start
it.

As a possible way to avoid wasting resources for too long, let's simply
add a timeout of 30 minutes in the execution of the e2e tests.  This is
10 minutes more than what's been observed as the total time taken by
this step.

---

This is related to https://github.com/confidential-containers/operator/issues/309, but doesn't cover the tests split into reusable parts.