### PR TITLE
docs: small clarification about non-namespaced resources

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -19,7 +19,8 @@ export RELEASE_VERSION=<RELEASE_VERSION>
 kubectl apply -k "github.com/confidential-containers/operator/config/release?ref=${RELEASE_VERSION}"
 ```
 
-The operator deploys all resources under `confidential-containers-system` namespace.
+While also managing certain cluster-wide resources, the operator primarily deploys resources within the confidential-containers-system namespace.
+
 
 Wait until each pod has the STATUS of Running.
 


### PR DESCRIPTION
Just a small fix/clarification.

Not all resources are in a namespace. Some resources like CRDs, ClusterRoles and ClusterRoleBinding are non-namespaced resources. Lets make this clear.