### PR TITLE
tests/ansible: Add fedora  linux distros

### DIFF
--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -6,6 +6,10 @@ build_pkgs:
     - make
     - gcc
     - qemu-user-static
+  fedora:
+    - make
+    - gcc
+    - qemu-user-static
   centos:
     - make
     - gcc
@@ -16,12 +20,17 @@ kubeadm_pkgs:
   ubuntu:
     - conntrack
     - socat
+  fedora:
+    - conntrack
+    - socat
   centos:
     - conntrack
     - socat
 k8s_version: v1.24.0
 test_pkgs:
   ubuntu:
+    - jq
+  fedora:
     - jq
   centos:
     - jq

--- a/tests/e2e/ansible/install_docker.yaml
+++ b/tests/e2e/ansible/install_docker.yaml
@@ -114,6 +114,24 @@
       systemd:
         daemon_reload: yes
   when: ansible_distribution == "Ubuntu" and ansible_architecture == 's390x'
+- name: Handle docker installation on Fedora 39
+  block:
+    - name: Install yum-utils
+      dnf:
+        name: yum-utils
+        state: present
+    - name: Add docker yum repo
+      shell: yum-config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+      args:
+        creates: /etc/yum.repos.d/docker-ce.repo
+    - name: Install docker packages
+      dnf:
+        name:
+          - containerd.io
+          - docker-ce
+          - docker-ce-cli
+        state: present
+  when: docker_exist.rc != 0 and ansible_distribution == "Fedora"
 - name: Start docker service
   service:
     name: docker

--- a/tests/e2e/ansible/install_kubeadm.yaml
+++ b/tests/e2e/ansible/install_kubeadm.yaml
@@ -50,6 +50,11 @@
         - kubeadm
         - kubelet
         - kubectl
+    - name: Remove zram-generator-defaults in Fedora
+      ansible.builtin.yum:
+        name: zram-generator-defaults
+        state: absent
+      when: ansible_distribution == "Fedora"
     - name: Disable swap
       shell: |
         [ -z "$(swapon --show)" ] && exit 0


### PR DESCRIPTION
Fedora also can be used to run k8s clusters locally. Add the fedora requirements to allow for testing.