### PR TITLE
kata-payload: Make resources for s390x overridden by base

### DIFF
--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -4,9 +4,11 @@ kind: Kustomization
 nameSuffix: -s390x
 
 resources:
-- ../default
+- ../base
 
 images:
+- name: quay.io/confidential-containers/reqs-payload
+  newTag: latest
 - name: quay.io/kata-containers/kata-deploy
   newName: quay.io/kata-containers/kata-deploy-ci
   newTag: kata-containers-latest


### PR DESCRIPTION
Due to the fact that kustomize does not allow the 2nd level of resource patch, this commit is to make the resources overridden by base directly.

Fixes: #320

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>