### PR TITLE
tests/git-helper.sh: fix yq checking

### DIFF
--- a/tests/git-helper.sh
+++ b/tests/git-helper.sh
@@ -23,7 +23,7 @@ function install_jq() {
 }
 
 function configure_github() {
-	if [ ! command -v jq &> /dev/null ]; then
+	if ! command -v jq &> /dev/null; then
 		echo "jq is not installed, installing it"
 		install_jq
 	fi


### PR DESCRIPTION
`[ ! command -v jq &> /dev/null ]` doesn't work for checking the existing of yq because if enclosed in `[]` it won't check the return code of `command`.

---

Found this problem when running the CI jobs for PR #338.
I don't know why  on previous execution jq existed on the system so that we didn't catch the issue before.