### PR TITLE
CI: Improve e2e tests reliability

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -62,7 +62,7 @@ jobs:
           if [ $RUNNING_INSTANCE = "s390x" ]; then
             args=""
           fi
-          ./run-local.sh -r "${{ matrix.runtimeclass }}" "${args}"
+          ./run-local.sh -t -r "${{ matrix.runtimeclass }}" "${args}"
         env:
           RUNNING_INSTANCE: ${{ matrix.instance }}
 

--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -164,9 +164,9 @@ uninstall_ccruntime() {
 	popd >/dev/null
 
 	# Wait and ensure ccruntime pods are gone
-	#
-	local cmd="! sudo -E kubectl get pods -n $op_ns |"
-	cmd+="grep -q -e cc-operator-daemon-install"
+	# (ensure failing kubectl keeps iterating)
+	local cmd="_OUT=\$(sudo -E kubectl get pods -n '$op_ns')"
+	cmd+=" && ! echo \$_OUT | grep -q -e cc-operator-daemon-install"
 	cmd+=" -e cc-operator-pre-install-daemon"
 	if ! wait_for_process 720 30 "$cmd"; then
 		echo "ERROR: there are ccruntime pods still running"
@@ -242,10 +242,9 @@ uninstall_operator() {
 	popd >/dev/null
 
 	# Wait and ensure the controller pod is gone
-	#
-	local pod="cc-operator-controller-manager"
-	local cmd="! kubectl get pods -n $op_ns |"
-	cmd+="grep -q $pod"
+	# (ensure failing kubectl keeps iterating)
+	local cmd="_OUT=\$(sudo -E kubectl get pods -n '$op_ns')"
+	cmd+="&& ! echo \$_OUT | grep -q -e cc-operator-controller-manager"
 	if ! wait_for_process 180 30 "$cmd"; then
 		echo "ERROR: the controller manager is still running"
 

--- a/tests/e2e/operator_tests.bats
+++ b/tests/e2e/operator_tests.bats
@@ -8,6 +8,9 @@
 load "${BATS_TEST_DIRNAME}/lib.sh"
 test_tag="[cc][operator]"
 
+# Set 10m timeout for each test
+export BATS_TEST_TIMEOUT=600
+
 is_operator_installed() {
 	[ "$(kubectl get deployment -n "$ns" --no-headers 2>/dev/null | wc -l)" \
 		-gt 0 ]

--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -76,9 +76,12 @@ undo_changes() {
 }
 
 on_exit() {
+	RET="$?"
 	if [ "$undo" == "true" ]; then
+		[ "$RET" -ne 0 ] && echo && echo "ERROR: Testing failed with $RET, starting the cleanup..."
 		undo_changes
 	fi
+	[ "$RET" -ne 0 ] && echo && echo "ERROR: Testing failed with $RET" || echo "INFO: Testing passed"
 }
 
 trap on_exit EXIT

--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -15,6 +15,7 @@ step_start_cluster=0
 step_install_operator=0
 runtimeclass=""
 undo="false"
+timeout="false"
 
 usage() {
 	cat <<-EOF
@@ -29,18 +30,29 @@ usage() {
                          the tests. Defaults to "kata-qemu".
 	-u: undo the installation and configuration before exiting. Useful for
 	    baremetal machine were it needs to do clean up for the next tests.
+	-t: enable default timeout for each operation (useful for CI)
 	EOF
 }
 
 parse_args() {
-	while getopts "hr:u" opt; do
+	while getopts "hr:ut" opt; do
 		case $opt in
 			h) usage && exit 0;;
 			r) runtimeclass="$OPTARG";;
 			u) undo="true";;
+			t) timeout="true";;
 			*) usage && exit 1;;
 		esac
 	done
+}
+
+run() {
+	duration=$1; shift
+	if [ "$timeout" == "true" ]; then
+		timeout $duration "$@"
+	else
+		"$@"
+	fi
 }
 
 undo_changes() {
@@ -48,17 +60,17 @@ undo_changes() {
 	# Do not try to undo steps that did not execute.
 	if [ $step_install_operator -eq 1 ]; then
 		echo "INFO: Uninstall the operator"
-		sudo -E PATH="$PATH" bash -c './operator.sh uninstall' || true
+		run 10m sudo -E PATH="$PATH" bash -c './operator.sh uninstall' || true
 	fi
 
 	if [ $step_start_cluster -eq 1 ]; then
 		echo "INFO: Shutdown the cluster"
-		sudo -E PATH="$PATH" bash -c './cluster/down.sh' || true
+		run 5m sudo -E PATH="$PATH" bash -c './cluster/down.sh' || true
 	fi
 
 	if [ $step_bootstrap_env -eq 1 ]; then
 		echo "INFO: Undo the bootstrap"
-		ansible-playbook -i localhost, -c local --tags undo ansible/main.yml || true
+		run 5m ansible-playbook -i localhost, -c local --tags undo ansible/main.yml || true
 	fi
 	popd >/dev/null
 }
@@ -87,19 +99,19 @@ main() {
 	pushd "$script_dir" >/dev/null
 	echo "INFO: Bootstrap the local machine"
 	step_bootstrap_env=1
-	ansible-playbook -i localhost, -c local --tags untagged ansible/main.yml
+	run 10m ansible-playbook -i localhost, -c local --tags untagged ansible/main.yml
 
 	echo "INFO: Bring up the test cluster"
 	step_start_cluster=1
-	sudo -E PATH="$PATH" bash -c './cluster/up.sh'
+	run 10m sudo -E PATH="$PATH" bash -c './cluster/up.sh'
 	export KUBECONFIG=/etc/kubernetes/admin.conf
 
 	echo "INFO: Build and install the operator"
 	step_install_operator=1
-	sudo -E PATH="$PATH" bash -c './operator.sh'
+	run 20m sudo -E PATH="$PATH" bash -c './operator.sh'
 
 	echo "INFO: Run tests"
-	cmd="sudo -E PATH=\"$PATH\" bash -c "
+	cmd="run 20m sudo -E PATH=\"$PATH\" bash -c "
 	if [ -z "$runtimeclass" ]; then
 		cmd+="'./tests_runner.sh'"
 	else


### PR DESCRIPTION
There are several improvements to the e2e pipeline to avoid odd returns as well as to interrupt on hangs. Last but not least I added extra messages that should improve reading the logs.

I'm definitely open to suggestions to remove/improve individual commits....