### PR TITLE
CI: Use ubuntu-22.04 and not ubuntu-latest in workflows

### DIFF
--- a/.github/workflows/docker-publish-latest-on-merge.yml
+++ b/.github/workflows/docker-publish-latest-on-merge.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish-on-tag.yml
+++ b/.github/workflows/docker-publish-on-tag.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pre-install-image-publish-on-merge.yml
+++ b/.github/workflows/pre-install-image-publish-on-merge.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   buid:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
We should at least be consistent with the ubuntu base images we're running in the workflows. I also opt to use ubuntu-22.04 and not ubuntu-latest.

Other repos in the org can take a similar change if reviewers want.