### PR TITLE
crd: Expose agent{Https,No}Proxy

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -46,5 +46,15 @@ patches:
         # the case, please, set this variable to `true`
         - name: "INSTALL_OFFICIAL_CONTAINERD"
           value: "false"
+        # If set, the Kata Containers agent https_proxy will be set to the
+        # specified value allowing then the pod sandbox to correctly pull
+        # images in such environment. 
+        # - name: "AGENT_HTTPS_PROXY"
+        #   value: "https://proxy.example.com:3129"
+        # If set, the Kata Containers agent no_proxy will be set to the
+        # specified value allowing then the pod sandbox to correctly pull
+        # images in such environment.
+        # - name: "AGENT_NO_PROXY"
+        #   value: "*.test.example.com,.example.org,127.0.0.0/8"
   target:
     kind: CcRuntime


### PR DESCRIPTION
Depending on the environment where we deploy Confidential Containers, setting up the proxy is required for the agent to be able to connect with the external world.

With that in mind, mainly considering this is needed for the basic TDX CI, let's ensure we expose to the users a way to set it up.