### PR TITLE
CI: bump go version to 1.21.7

### DIFF
--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
         check-latest: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/operator
 
-go 1.20
+go 1.21
 
 require (
 	github.com/confidential-containers/cloud-api-adaptor/peerpod-ctrl v0.8.0-alpha.1.0.20240204080936-372e4e72f7fe

--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -14,7 +14,7 @@ build_pkgs:
     - make
     - gcc
 container_runtime: containerd
-go_version: 1.20.7
+go_version: 1.21.7
 # conntrack and socat are needed by the `kubeadm init` preflight checks
 kubeadm_pkgs:
   ubuntu:


### PR DESCRIPTION
Please check out the issue below for details.

It is to update a go version to 1.21.7 which makes the CI go green again.

Fixes: #356

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>