### PR TITLE
Add "make clean" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ endif
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
+.PHONY: clean
+clean:  ## Cleanup the build generated files
+	rm -Rf bin/ cover.out bundle_tmp*
+
 ##@ Deployment
 
 ifndef ignore-not-found


### PR DESCRIPTION
to provide a standard way to clean the environment after build.

Note I'm not a heavy "go" user so I simply took the paths from ".gitignore". I experimented with "go clean" but it did not work for me.