### PR TITLE
Release: update docker manifest create commands

### DIFF
--- a/.github/workflows/pre-install-image-publish-on-merge.yaml
+++ b/.github/workflows/pre-install-image-publish-on-merge.yaml
@@ -19,7 +19,7 @@ env:
   REGISTRY: quay.io
 
 jobs:
-  buid:
+  build:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -83,13 +83,13 @@ function build_payload() {
 
 	docker manifest create "${extra_docker_manifest_flags}" \
 		"${registry}:${tag}" \
-		--amend "${registry}:x86_64-${tag}" \
-		--amend "${registry}:s390x-${tag}"
+		"${registry}:x86_64-${tag}" \
+		"${registry}:s390x-${tag}"
 
 	docker manifest create "${extra_docker_manifest_flags}" \
 		"${registry}:latest" \
-		--amend "${registry}:x86_64-${tag}" \
-		--amend "${registry}:s390x-${tag}"
+		"${registry}:x86_64-${tag}" \
+		"${registry}:s390x-${tag}"
 
 	docker manifest push "${extra_docker_manifest_flags}" "${registry}:${tag}"
 	docker manifest push "${extra_docker_manifest_flags}" "${registry}:latest"


### PR DESCRIPTION
This is attempting to fix the failing GHA action [here](https://github.com/confidential-containers/operator/actions/workflows/pre-install-image-publish-on-merge.yaml) so that the v0.9.0 release can continue.

`docker manifest create` example is [here](https://docs.docker.com/reference/cli/docker/manifest/):
```
docker manifest create 45.55.81.106:5000/coolapp:v1 \
    45.55.81.106:5000/coolapp-ppc64le-linux:v1 \
    45.55.81.106:5000/coolapp-arm-linux:v1 \
    45.55.81.106:5000/coolapp-amd64-linux:v1 \
    45.55.81.106:5000/coolapp-amd64-windows:v1
```