### PR TITLE
tests: remove deprecated ansible option

### DIFF
--- a/tests/e2e/ansible/install_containerd.yaml
+++ b/tests/e2e/ansible/install_containerd.yaml
@@ -31,7 +31,6 @@
         containerd config default > /etc/containerd/config.toml
       args:
         executable: /bin/bash
-        warn: false
     - name: Restart containerd service
       service:
         name: containerd

--- a/tests/e2e/ansible/install_test_deps.yaml
+++ b/tests/e2e/ansible/install_test_deps.yaml
@@ -43,7 +43,6 @@
         cp -f ./kustomize /usr/local/bin
       args:
         creates: /usr/local/bin/kustomize
-        warn: false
       retries: 3
       delay: 10
       when: kustomize_exist.rc != 0


### PR DESCRIPTION
Ansible used to have a "feature" where it would warn you if you wrote a shell command that could be implemented with a module instead. The shell option had an option to disable these warnings.

These features were deprecated in ansible 2.11 and removed in anbsible 2.14. This PR removes the warn option. Otherwise the playbooks won't work. 

This does mean that people using an older version of ansible might see the warnings.