### PR TITLE
ci: update enclave-cc tests

### DIFF
--- a/.github/workflows/enclave-cc-cicd.yaml
+++ b/.github/workflows/enclave-cc-cicd.yaml
@@ -55,6 +55,5 @@ jobs:
 
       - name: Deploy sample workload
         run: |
-          sed -i -e 's:boot_instance:occlum_instance:' tests/e2e/enclave-cc-pod-sim.yaml
           kubectl apply -f tests/e2e/enclave-cc-pod-sim.yaml
           kubectl wait --for=condition=Ready pod/enclave-cc-pod-sim

--- a/.github/workflows/enclave-cc-e2e.yaml
+++ b/.github/workflows/enclave-cc-e2e.yaml
@@ -66,6 +66,5 @@ jobs:
 
       - name: Deploy sample workload
         run: |
-          sed -i -e 's:boot_instance:occlum_instance:' tests/e2e/enclave-cc-pod-sim.yaml
           kubectl apply -f tests/e2e/enclave-cc-pod-sim.yaml
           kubectl wait --for=condition=Ready pod/enclave-cc-pod-sim

--- a/tests/e2e/enclave-cc-pod-sim.yaml
+++ b/tests/e2e/enclave-cc-pod-sim.yaml
@@ -11,7 +11,7 @@ spec:
     env:
     - name: OCCLUM_RELEASE_ENCLAVE
       value: "0"
-    workingDir: "/run/rune/boot_instance/"
+    workingDir: "/run/rune/occlum_instance/"
     command:
-    - /run/rune/boot_instance/build/bin/occlum-run
+    - /run/rune/occlum_instance/build/bin/occlum-run
     - /bin/hello_world


### PR DESCRIPTION
Now that both e2e (for PRs) and cicd (nightly) tests are using the updated payloads with the new Occlum instance path, we can drop the sed lines and update the test deployment use the new path directly.