### PR TITLE
Draft: Improve cri-o support by using pull_type

### DIFF
--- a/api/v1beta1/ccruntime_types.go
+++ b/api/v1beta1/ccruntime_types.go
@@ -319,6 +319,7 @@ type RuntimeClass struct {
 	Name string `json:"name"`
 	// The snapshotter to be used by the runtime class
 	Snapshotter string `json:"snapshotter"`
+	PullType    string `json:"pulltype"`
 }
 
 func init() {

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -19,14 +19,19 @@ patches:
       value:
       - name: "kata-clh"
         snapshotter: "nydus"
+        pulltype: ""
       - name: "kata-qemu"
         snapshotter: "nydus"
+        pulltype: ""
       - name: "kata-qemu-tdx"
         snapshotter: "nydus"
+        pulltype: ""
       - name: "kata-qemu-sev"
         snapshotter: "nydus"
+        pulltype: ""
       - name: "kata-qemu-snp"
         snapshotter: "nydus"
+        pulltype: ""
     - op: add
       path: /spec/config/defaultRuntimeClassName
       value: "kata-qemu"

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -21,6 +21,7 @@ patches:
       value:
       - name: "kata-remote"
         snapshotter: "nydus"
+        pulltype: "guest-pull"
     - op: add
       path: /spec/config/debug
       value: false

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -19,8 +19,10 @@ patches:
       value:
       - name: "kata-qemu"
         snapshotter: "nydus"
+        pulltype: ""
       - name: "kata-qemu-se"
         snapshotter: "nydus"
+        pulltype: ""
     - op: add
       path: /spec/config/defaultRuntimeClassName
       value: "kata-qemu"

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -630,6 +630,7 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 
 	var shims []string
 	var snapshotter_handler_mapping []string
+	var pull_type_mapping []string
 	for _, runtimeClass := range r.ccRuntime.Spec.Config.RuntimeClasses {
 		// Similarly to what's being done for the default shim, let's remove
 		// the "kata-" prefix from the runtime class names
@@ -639,6 +640,11 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 		if runtimeClass.Snapshotter != "" {
 			mapping := shim + ":" + runtimeClass.Snapshotter
 			snapshotter_handler_mapping = append(snapshotter_handler_mapping, mapping)
+		}
+
+		if runtimeClass.PullType != "" {
+			mapping := shim + ":" + runtimeClass.PullType
+			pull_type_mapping = append(pull_type_mapping, mapping)
 		}
 	}
 
@@ -674,6 +680,10 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 		{
 			Name:  "SNAPSHOTTER_HANDLER_MAPPING",
 			Value: strings.Join(snapshotter_handler_mapping, ","),
+		},
+		{
+			Name:  "PULL_TYPE_MAPPING",
+			Value: strings.Join(pull_type_mapping, ","),
 		},
 	}
 	envVars = append(envVars, r.ccRuntime.Spec.Config.EnvironmentVariables...)

--- a/tests/e2e/ansible/group_vars/all
+++ b/tests/e2e/ansible/group_vars/all
@@ -26,7 +26,7 @@ kubeadm_pkgs:
   centos:
     - conntrack
     - socat
-k8s_version: v1.24.0
+k8s_version: v1.28.0
 test_pkgs:
   ubuntu:
     - jq


### PR DESCRIPTION
Kata containers is introducing a handler for PULL_TYPE variable to allow configuring CRI-O for guest-pull image pulling.
Lets adapt the operator to propagate this variable.

Most of the work here was made by @wainersm before leaving PTO, I just fixed a few things.

This is related to #365.

PLEASE DO NOT MERGE, this is depends on https://github.com/kata-containers/kata-containers/pull/9537