### PR TITLE
pre-reqs: Bump reqs-payload image

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e36bf9d3214421bad4f9e8e054b44c7008d33ec7
+  newTag: 290ae5f8432f81754dcdc5708ed1488e3986d79b
 - name: quay.io/kata-containers/kata-deploy
   newTag: 3.4.0
 

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e36bf9d3214421bad4f9e8e054b44c7008d33ec7
+  newTag: 290ae5f8432f81754dcdc5708ed1488e3986d79b
 - name: quay.io/kata-containers/kata-deploy
   newTag: 3.4.0
 

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e36bf9d3214421bad4f9e8e054b44c7008d33ec7
+  newTag: 290ae5f8432f81754dcdc5708ed1488e3986d79b
 - name: quay.io/kata-containers/kata-deploy
   newTag: 3.4.0
 

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -8,4 +8,4 @@ nameSuffix: -sgx-mode-hw
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e36bf9d3214421bad4f9e8e054b44c7008d33ec7
+  newTag: 290ae5f8432f81754dcdc5708ed1488e3986d79b

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -7,4 +7,4 @@ images:
 - name: quay.io/confidential-containers/runtime-payload
   newTag: enclave-cc-SIM-sample-kbc-v0.9.0
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: e36bf9d3214421bad4f9e8e054b44c7008d33ec7
+  newTag: 290ae5f8432f81754dcdc5708ed1488e3986d79b


### PR DESCRIPTION
- After we updated to pick up nydus-snapshotter v0.3.13 in the pre-reqs image, start picking up this version.