### PR TITLE
peer-pods: Comment out peerpodsconfig.yaml

### DIFF
--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -5,7 +5,7 @@ nameSuffix: -peer-pods
 
 resources:
 - ../base
-- peerpodsconfig.yaml
+# - peerpodsconfig.yaml
 
 images:
 - name: quay.io/confidential-containers/reqs-payload


### PR DESCRIPTION
- We have a bunch of outstanding issues with the peerpodsconfig change that moved the management of the cloud-api-adaptor daemonset and peer-pods configmap to be owned by the operator rather than cloud-api-adaptor. In order to try and switch away from the outdated 0.8 operator and consume the main kata payload we decided to switch back to the cloud-api-adaptor managing it's daemonset and config, until we can find a testable and strategic path for the operator management, so we'll comment out the kustomize that runs peerpodsconfig-ctrl until we have that solution