### PR TITLE
CI: Pin requests' version less than 2.32

### DIFF
--- a/tests/e2e/ansible/start_docker_registry.yaml
+++ b/tests/e2e/ansible/start_docker_registry.yaml
@@ -19,19 +19,15 @@
         state: present
       retries: 3
       delay: 10
-    # The docker pip is needed by the docker_container ansible module itself.
-    - name: Install docker pip
+    # The docker and requests pip packages are required by the docker_container ansible module itself.
+    # The requests package is pinned to a version less than 2.32 to avoid a bug
+    # at https://github.com/docker/docker-py/issues/3256
+    - name: Install docker and requests pip packages
       pip:
-        name: docker
-    # Due to a bug in requests 2.29.0 we need to downgrade it
-    # see https://github.com/docker/docker-py/issues/3113 
-    - name: Downgrade requests
-      shell: |
-        actual_version="$(pip3 show requests | grep Version | cut -d: -f2 | xargs)"
-        version_ge="$(echo -e "2.29.0\n$actual_version" | sort -V | head -1)"
-        if [ "$version_ge" = "2.29.0" ]; then
-            pip3 install requests==2.28.1
-        fi
+        name:
+          - docker
+          - requests<2.32
+        state: present
       retries: 3
       delay: 10
     - name: Start a docker registry


### PR DESCRIPTION
The issue https://github.com/docker/docker-py/issues/3113 seems to be resolved. The pinned version of requests (2.28.1) is no longer compatible with the current docker pip, resulting in errors like:

```
"Error connecting: Error while fetching server API version: Not supported URL scheme http+docker"
```

Initially, we attempted to allow pip to install requests according to its dependency tree.
However, the issue persists on Ubuntu 22.04, and it appears to be related to https://github.com/docker/docker-py/issues/3256.
The best solution so far is to pin the version of the package to less than 2.32.

The change is verified at https://github.com/confidential-containers/operator/actions/runs/9204691086?pr=382

Fixes: #381 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
