### PR TITLE
ci: Run the e2e tests on TDX

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -21,14 +21,10 @@ jobs:
       matrix:
         runtimeclass:
           - "kata-qemu"
-          - "kata-clh"
         instance:
           - "az-ubuntu-2004"
           - "az-ubuntu-2204"
           - "s390x"
-        exclude:
-          - runtimeclass: "kata-clh"
-            instance: "s390x"
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Take a pre-action for self-hosted runner

--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -25,6 +25,13 @@ jobs:
           - "az-ubuntu-2004"
           - "az-ubuntu-2204"
           - "s390x"
+          - "tdx"
+        exclude:
+          - runtimeclass: "kata-qemu"
+            instance: "tdx"
+        include:
+          - runtimeclass: "kata-qemu-tdx"
+            instance: "tdx"
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Take a pre-action for self-hosted runner

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -84,7 +84,7 @@ Kind version `v0.16.0` have been successfully tested on the following Linux dist
 - `Ubuntu 20.04`
 - `Ubuntu 22.04`
 
->**Note**: Only `kata-clh` runtimeclass works with Kind cluster.
+>**Note**: Kind clusters are not supported
 
 ## Continuous Integration (CI)
 
@@ -97,8 +97,6 @@ The following jobs will check for regessions on the default CcRuntime:
 |Job name | TEE | OS | VMM |
 |---|---|---|---|
 |e2e-pr / operator tests (kata-qemu, s390x) | Non-TEE | Ubuntu 22.04 (s390x) | QEMU |
-|e2e-pr / operator tests (kata-clh, az-ubuntu-2004) | Non-TEE |  Ubuntu 20.04 | Cloud Hypervisor |
-|e2e-pr / operator tests (kata-clh, az-ubuntu-2204) | Non-TEE |  Ubuntu 22.04 | Cloud Hypervisor |
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2004) | Non-TEE |  Ubuntu 20.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2204) | Non-TEE |  Ubuntu 22.04 | QEMU |
 
@@ -172,7 +170,7 @@ export PATH="$PATH:/usr/local/bin"
 
 where:
 
-* ``-r "kata-qemu"`` - configures the runtime class (you can use ``kata-clh`` as an alternative)
+* ``-r "kata-qemu"`` - configures the runtime class
 * ``-u`` - performs mild cleanup afterwards (but it's not thorough and might alter pre-existing configuration)
 
 If you intend to run the tests multiple times, you can run it without the ``-u`` which leaves the configured kubernetes cluster running. Then you can configure the rootless environment by:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -99,6 +99,7 @@ The following jobs will check for regessions on the default CcRuntime:
 |e2e-pr / operator tests (kata-qemu, s390x) | Non-TEE | Ubuntu 22.04 (s390x) | QEMU |
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2004) | Non-TEE |  Ubuntu 20.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2204) | Non-TEE |  Ubuntu 22.04 | QEMU |
+|e2e-pr / operator tests (kata-qemu-tdx, tdx) | TDX |  Ubuntu 24.04 | QEMU |
 
 Additionally the following jobs will check regressions on the enclave-cc CcRuntime:
 


### PR DESCRIPTION
Please, see each commit message for more details.

Although we don't have a TDX machine plugged yet, it'd be good to have this reviewed as the tests won't be able to run before they're merged, as it's relying the `pull_request_target` event.

Once the TDX machine is ready, I'd be fine on having this one merged (after review, of course).
