### PR TITLE
Makefile: scripts: Add build args for proxy when using docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 
+http_proxy := ""
+https_proxy := ""
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -143,9 +146,9 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: test ## Build docker image with the manager.
 ifneq (, $(PEERPODS))
 	@echo PEERPODS is enabled
-	docker build -t ${IMG} -f Dockerfile.peerpods .
+	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) -t ${IMG} -f Dockerfile.peerpods .
 else
-	docker build -t ${IMG} .
+	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) -t ${IMG} .
 endif
 
 .PHONY: docker-push
@@ -270,7 +273,7 @@ bundle: manifests kustomize operator-sdk## Generate bundle manifests and metadat
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -12,6 +12,8 @@ vfio_gpu_containerd_repo=${vfio_gpu_containerd_repo:-"https://github.com/confide
 nydus_snapshotter_repo=${nydus_snapshotter_repo:-"https://github.com/containerd/nydus-snapshotter"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
 extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
+http_proxy="${http_proxy:-}"
+https_proxy="${https_proxy:-}"
 
 registry="${registry:-quay.io/confidential-containers/reqs-payload}"
 
@@ -59,6 +61,8 @@ function build_payload() {
 
 		echo "Building containerd payload image for ${arch}"
 		docker buildx build \
+			--build-arg HTTP_PROXY="${http_proxy}" \
+			--build-arg HTTPS_PROXY="${https_proxy}" \
 			--build-arg ARCH="${golang_arch}" \
 			--build-arg COCO_CONTAINERD_VERSION="${coco_containerd_version}" \
 			--build-arg COCO_CONTAINERD_REPO="${coco_containerd_repo}" \

--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -70,7 +70,7 @@ undo_changes() {
 
 	if [ $step_bootstrap_env -eq 1 ]; then
 		echo "::info:: Undo the bootstrap"
-		run 5m ansible-playbook -i localhost, -c local --tags undo ansible/main.yaml || true
+		run 5m sudo -E ansible-playbook -i localhost, -c local --tags undo ansible/main.yaml || true
 	fi
 	popd >/dev/null
 }
@@ -102,7 +102,7 @@ main() {
 	pushd "$script_dir" >/dev/null
 	echo "::info:: Bootstrap the local machine"
 	step_bootstrap_env=1
-	run 10m ansible-playbook -i localhost, -c local --tags untagged ansible/main.yaml
+	run 10m sudo -E ansible-playbook -i localhost, -c local --tags untagged ansible/main.yaml
 
 	echo "::info:: Bring up the test cluster"
 	step_start_cluster=1


### PR DESCRIPTION
This PR adds build args for proxy when using docker build, this is specially needed when we are behind a proxy to avoid failures.