### PR TITLE
Revert "Makefile: scripts: Add build args for proxy when using docker…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,6 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 
-http_proxy := ""
-https_proxy := ""
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -146,9 +143,9 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: test ## Build docker image with the manager.
 ifneq (, $(PEERPODS))
 	@echo PEERPODS is enabled
-	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) -t ${IMG} -f Dockerfile.peerpods .
+	docker build -t ${IMG} -f Dockerfile.peerpods .
 else
-	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) -t ${IMG} .
+	docker build -t ${IMG} .
 endif
 
 .PHONY: docker-push
@@ -273,7 +270,7 @@ bundle: manifests kustomize operator-sdk## Generate bundle manifests and metadat
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build --build-arg http_proxy=$(http_proxy) --build-arg https_proxy=$(https_proxy) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -12,8 +12,6 @@ vfio_gpu_containerd_repo=${vfio_gpu_containerd_repo:-"https://github.com/confide
 nydus_snapshotter_repo=${nydus_snapshotter_repo:-"https://github.com/containerd/nydus-snapshotter"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
 extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
-http_proxy="${http_proxy:-}"
-https_proxy="${https_proxy:-}"
 
 registry="${registry:-quay.io/confidential-containers/reqs-payload}"
 
@@ -61,8 +59,6 @@ function build_payload() {
 
 		echo "Building containerd payload image for ${arch}"
 		docker buildx build \
-			--build-arg HTTP_PROXY="${http_proxy}" \
-			--build-arg HTTPS_PROXY="${https_proxy}" \
 			--build-arg ARCH="${golang_arch}" \
 			--build-arg COCO_CONTAINERD_VERSION="${coco_containerd_version}" \
 			--build-arg COCO_CONTAINERD_REPO="${coco_containerd_repo}" \

--- a/tests/e2e/ansible/install_containerd.yaml
+++ b/tests/e2e/ansible/install_containerd.yaml
@@ -11,7 +11,7 @@
   tasks:
     - name: Install containerd from distro
       package:
-        name: "{{ 'containerd.io' if ansible_distribution_version != '22.04' else 'containerd' }}"
+        name: "{{ 'containerd.io' if ansible_distribution_version == '20.04' else 'containerd' }}"
         state: present
     # The docker package overwrite the /etc/containerd/config.toml installed
     # by the containerd.io package. As a result we are hit by the following

--- a/tests/e2e/ansible/install_docker.yaml
+++ b/tests/e2e/ansible/install_docker.yaml
@@ -54,7 +54,7 @@
         state: present
       # TODO: add regular non-root users to docker group
   when: docker_exist.rc != 0 and ansible_distribution == "Ubuntu" and ansible_distribution_version == "20.04"
-- name: Handle docker installation on Ubuntu 22.04
+- name: Handle docker installation on Ubuntu 22.04 and 24.04
   block:
     - name: Install docker packages
       package:
@@ -70,7 +70,7 @@
         state: present
       retries: 3
       delay: 10
-  when: docker_exist.rc != 0 and ansible_distribution == "Ubuntu" and ansible_distribution_version == "22.04"
+  when: docker_exist.rc != 0 and ansible_distribution == "Ubuntu" and ansible_distribution_version in ("22.04", "24.04")
 - name: Handle docker installation on CentOS.
   block:
     - name: Install yum-utils

--- a/tests/e2e/ansible/start_docker_registry.yaml
+++ b/tests/e2e/ansible/start_docker_registry.yaml
@@ -12,24 +12,16 @@
     local_registry_port: 5000
     local_registry_name: local-registry
   tasks:
-    - name: Install pip3
+    - name: Install python3-docker and python3-requests
       package:
-        # TODO: this is ubuntu specific...
-        name: python3-pip
-        state: present
-      retries: 3
-      delay: 10
-    # The docker and requests pip packages are required by the docker_container ansible module itself.
-    # The requests package is pinned to a version less than 2.32 to avoid a bug
-    # at https://github.com/docker/docker-py/issues/3256
-    - name: Install docker and requests pip packages
-      pip:
         name:
-          - docker
-          - requests<2.32
+          # This is Ubuntu specific
+          - python3-docker
+          - python3-requests
         state: present
       retries: 3
       delay: 10
+      when: ansible_distribution == "Ubuntu"
     - name: Start a docker registry
       docker_container:
         name: "{{ local_registry_name }}"

--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -70,7 +70,7 @@ undo_changes() {
 
 	if [ $step_bootstrap_env -eq 1 ]; then
 		echo "::info:: Undo the bootstrap"
-		run 5m sudo -E ansible-playbook -i localhost, -c local --tags undo ansible/main.yaml || true
+		run 5m ansible-playbook -i localhost, -c local --tags undo ansible/main.yaml || true
 	fi
 	popd >/dev/null
 }
@@ -102,7 +102,7 @@ main() {
 	pushd "$script_dir" >/dev/null
 	echo "::info:: Bootstrap the local machine"
 	step_bootstrap_env=1
-	run 10m sudo -E ansible-playbook -i localhost, -c local --tags untagged ansible/main.yaml
+	run 10m ansible-playbook -i localhost, -c local --tags untagged ansible/main.yaml
 
 	echo "::info:: Bring up the test cluster"
 	step_start_cluster=1


### PR DESCRIPTION
… build"

This reverts commit 51171296c9b24c1e8b8d2a5fb500456d8302fddb.

Let's configure our CI to use redsocks instead, which theoretically helps us to avoid the whole proxy madness.