### PR TITLE
tests: Remove centos8 configuration

### DIFF
--- a/tests/e2e/Vagrantfile
+++ b/tests/e2e/Vagrantfile
@@ -57,16 +57,4 @@ Vagrant.configure("2") do |config|
     SHELL
   end
 
-    config.vm.define "tests-e2e-centosstream8", autostart: false do |centosstream8|
-    centosstream8.vm.box = "centos/stream8"
-    centosstream8.vm.provision "shell", inline: <<-SHELL
-      sudo dnf update -y
-      sudo dnf -y install ansible-core
-      # On CentOS the docker_container module is not available on ansible-core.
-      ansible-galaxy collection install community.docker
-      cd "#{guest_home_dir}/src/confidential-containers/operator/tests/e2e"
-      ./run-local.sh -r "#{runtimeclass}"
-    SHELL
-  end
-
 end


### PR DESCRIPTION
Centos8 is EOL and unavailable anymore. I tried centos9 but that one is incorrectly configured in Vagrant:

    https://github.com/hashicorp/vagrant/issues/13272

and besides we don't really care at this point. Let's remove centos completely.