### PR TITLE
ci: Enable running the ccruntime_e2e tests on AMD SEV/SNP nodes

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -26,12 +26,22 @@ jobs:
           - "az-ubuntu-2204"
           - "s390x"
           - "tdx"
+          - "coco-ci-amd-rome-001"
+          - "coco-ci-amd-milan-001"
         exclude:
           - runtimeclass: "kata-qemu"
             instance: "tdx"
+          - runtimeclass: "kata-qemu"
+            instance: "coco-ci-amd-rome-001"
+          - runtimeclass: "kata-qemu"
+            instance: "coco-ci-amd-milan-001"
         include:
           - runtimeclass: "kata-qemu-tdx"
             instance: "tdx"
+          - runtimeclass: "kata-qemu-sev"
+            instance: "coco-ci-amd-rome-001"
+          - runtimeclass: "kata-qemu-snp"
+            instance: "coco-ci-amd-milan-001"
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Take a pre-action for self-hosted runner

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -100,6 +100,8 @@ The following jobs will check for regessions on the default CcRuntime:
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2004) | Non-TEE |  Ubuntu 20.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2204) | Non-TEE |  Ubuntu 22.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu-tdx, tdx) | TDX |  Ubuntu 24.04 | QEMU |
+|e2e-pr / operator tests (kata-qemu-sev, coco-ci-amd-rome-001, ) | SEV |  Ubuntu 22.04 | QEMU |
+|e2e-pr / operator tests (kata-qemu-snp, coco-ci-amd-milan-001) | SNP |  Ubuntu 22.04 | QEMU |
 
 Additionally the following jobs will check regressions on the enclave-cc CcRuntime:
 


### PR DESCRIPTION
Enables testing of :

1. kata-qemu-sev runtime class on SEV and
2. kata-qemu-snp runtime class on the SNP 

self hosted runners respectively.

Updated documentation to reflect the same.