### PR TITLE
fix: add support for imagePullPolicy for installer daemonsets (#395)

### DIFF
--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -722,7 +722,7 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 						{
 							Name:            "cc-runtime-install-pod",
 							Image:           r.ccRuntime.Spec.Config.PayloadImage,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: imagePullPolicyOrDefault(r.ccRuntime.Spec.Config.ImagePullPolicy),
 							Lifecycle:       preStopHook,
 							SecurityContext: &corev1.SecurityContext{
 								// TODO - do we really need to run as root?
@@ -917,7 +917,7 @@ func (r *CcRuntimeReconciler) makeHookDaemonset(operation DaemonOperation) *apps
 						{
 							Name:            "cc-runtime-" + string(operation) + "-pod",
 							Image:           image,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: imagePullPolicyOrDefault(r.ccRuntime.Spec.Config.ImagePullPolicy),
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &runPrivileged,
 								RunAsUser:  &runAsUser,

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -1,5 +1,9 @@
 package controllers
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 // DaemonOperation represents the operation the daemon is going to perform
 type DaemonOperation string
 
@@ -26,6 +30,8 @@ const (
 	UpgradeOperation DaemonOperation = "upgrade"
 
 	RuntimeConfigFinalizer = "runtimeconfig.confidentialcontainers.org/finalizer"
+
+	DefaultImagePullPolicy = corev1.PullAlways
 )
 
 func contains(list []string, s string) bool {
@@ -35,4 +41,11 @@ func contains(list []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func imagePullPolicyOrDefault(policy corev1.PullPolicy) corev1.PullPolicy {
+	if policy == "" {
+		return DefaultImagePullPolicy
+	}
+	return policy
 }


### PR DESCRIPTION
This PR implements support for ImagePullPolicy which is present in the CRD but not actually used (default Always).