### PR TITLE
tests.e2e.ansible: Fix to increase github rate limiting for kustomize

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -78,6 +78,7 @@ jobs:
           ./run-local.sh -t -r "${{ matrix.runtimeclass }}" "${args}"
         env:
           RUNNING_INSTANCE: ${{ matrix.instance }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Take a post-action
         if: always()

--- a/tests/e2e/ansible/install_test_deps.yaml
+++ b/tests/e2e/ansible/install_test_deps.yaml
@@ -39,7 +39,7 @@
       ignore_errors: yes
     - name: Install kustomize
       shell: |
-        curl -s --retry 3 --retry-delay 10 "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        curl -s --retry 3 --retry-delay 10 -u ${USER}:${GITHUB_TOKEN} "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
         cp -f ./kustomize /usr/local/bin
       args:
         creates: /usr/local/bin/kustomize


### PR DESCRIPTION
This PR authenticates for github to increase the threshold for rate limiting while installing kustomize and avoid the random failures that are impacting several CIs.