### PR TITLE
DEBUG: Fix curl command to increase github rate limiting

### DIFF
--- a/tests/e2e/ansible/install_test_deps.yaml
+++ b/tests/e2e/ansible/install_test_deps.yaml
@@ -39,7 +39,7 @@
       ignore_errors: yes
     - name: Install kustomize
       shell: |
-        curl -s --retry 3 --retry-delay 10 -u ${USER}:${GITHUB_TOKEN} "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        curl -s --retry 3 --max-time 30 -u ${USER}:${GITHUB_TOKEN} -X GET "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
         cp -f ./kustomize /usr/local/bin
       args:
         creates: /usr/local/bin/kustomize


### PR DESCRIPTION
This PR fixes the correct curl command to increase the threshold for rate limiting while installing kustomize.