### PR TITLE
GHA: Remove {pre,post}-action steps for self-hosted runners

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -44,12 +44,6 @@ jobs:
             instance: "sev-snp"
     runs-on: ${{ matrix.instance }}
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: |
-          if [ -f ${HOME}/script/pre_action.sh ]; then
-            ${HOME}/script/pre_action.sh cc-operator
-          fi
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
@@ -79,10 +73,3 @@ jobs:
         env:
           RUNNING_INSTANCE: ${{ matrix.instance }}
           GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Take a post-action
-        if: always()
-        run: |
-          if [ -f ${HOME}/script/post_action.sh ]; then
-            ${HOME}/script/post_action.sh cc-operator
-          fi


### PR DESCRIPTION
The following hooks:

- ACTIONS_RUNNER_HOOK_JOB_STARTED
- ACTIONS_RUNNER_HOOK_JOB_COMPLETED

could perfectly replace the existing {pre,post}-action scripts and will make a workflow independent of the runner context. This PR wipes out all GHA steps where the actions are triggered.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>

@AdithyaKrishnan please let me know when the runner for SEV/SNP is ready for this. I will ask for review when you guys are ready. Thanks.