### PR TITLE
tests:e2e: Install kustomize from the Go source code

### DIFF
--- a/tests/e2e/ansible/install_test_deps.yaml
+++ b/tests/e2e/ansible/install_test_deps.yaml
@@ -33,19 +33,6 @@
                 path: bats-core
                 state: absent
           when: bats_exist.rc != 0
-    - name: Check kustomize is installed
-      shell: command -v kustomize >/dev/null 2>&1
-      register: kustomize_exist
-      ignore_errors: yes
-    - name: Install kustomize
-      shell: |
-        curl -s --retry 3 --retry-delay 10 -u ${USER}:${GITHUB_TOKEN} "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
-        cp -f ./kustomize /usr/local/bin
-      args:
-        creates: /usr/local/bin/kustomize
-      retries: 3
-      delay: 10
-      when: kustomize_exist.rc != 0
     - block:
       - name: Download Go tarball
         get_url:
@@ -65,6 +52,20 @@
           src: /usr/local/go/bin/go
           dest: /usr/local/bin/go
           state: link
+    - block:
+      - name: Check kustomize is installed
+        shell: command -v kustomize >/dev/null 2>&1
+        register: kustomize_exist
+        ignore_errors: yes
+      - name: Install kustomize
+        shell: |
+          GOBIN=/usr/local/bin GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@latest
+        args:
+          creates: /usr/local/bin/kustomize
+        retries: 3
+        delay: 10
+        when: kustomize_exist.rc != 0
+
     #
     # Undo the installation.
     #


### PR DESCRIPTION
This PR installs the kustomize CLI from source in order to avoid the random failures due to the Github Actions rate limitations.