### PR TITLE
tools: Bump controller-gen to v0.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
-CONTROLLER_TOOLS_VERSION ?= v0.9.2
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 OPERATOR_SDK_VERSION ?= v1.30.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"


### PR DESCRIPTION
A version of controller-gen is quite old and fails to run with the latest go:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

This PR updates the package to the latest version.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>