### PR TITLE
GHA: Change label from s390x to s390x-large

### DIFF
--- a/.github/workflows/ccruntime-nightly.yaml
+++ b/.github/workflows/ccruntime-nightly.yaml
@@ -11,7 +11,7 @@ jobs:
       commit-hash: ${{ github.sha }}
 
   e2e-ibm-se-nightly:
-    runs-on: s390x
+    runs-on: s390x-large
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -24,7 +24,7 @@ jobs:
         instance:
           - "az-ubuntu-2004"
           - "az-ubuntu-2204"
-          - "s390x"
+          - "s390x-large"
           - "tdx"
           - "sev"
           - "sev-snp"
@@ -66,7 +66,7 @@ jobs:
           cd tests/e2e
           export PATH="$PATH:/usr/local/bin"
           args="-u"
-          if [ $RUNNING_INSTANCE = "s390x" ]; then
+          if [ $RUNNING_INSTANCE = "s390x-large" ]; then
             args=""
           fi
           ./run-local.sh -t -r "${{ matrix.runtimeclass }}" "${args}"


### PR DESCRIPTION
Recently, an additional s390x runner was added to the organization. However, it is insufficient for running the operator e2e tests and will function as a supplementary builder.

This commit changes the label for the platform from s390x to s390x-large to differentiate the existing runner.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>