### PR TITLE
release: changes to publish 0.9.0 in operator hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.8.0
+VERSION ?= 0.9.0
 ARCH = $(shell uname -m)
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -53,6 +53,10 @@ metadata:
                 {
                   "mountPath": "/usr/local/bin/",
                   "name": "local-bin"
+                },
+                {
+                  "mountPath": "/host/",
+                  "name": "host"
                 }
               ],
               "installerVolumes": [
@@ -83,11 +87,18 @@ metadata:
                     "type": ""
                   },
                   "name": "local-bin"
+                },
+                {
+                  "hostPath": {
+                    "path": "/",
+                    "type": ""
+                  },
+                  "name": "host"
                 }
               ],
-              "payloadImage": "quay.io/kata-containers/kata-deploy-ci:kata-containers-latest",
+              "payloadImage": "quay.io/kata-containers/kata-deploy:3.7.0",
               "postUninstall": {
-                "image": "quay.io/confidential-containers/reqs-payload:latest",
+                "image": "quay.io/confidential-containers/reqs-payload:6bba65f96532fa280b3996dcad2aad10bed777e6",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",
@@ -149,7 +160,7 @@ metadata:
                 ]
               },
               "preInstall": {
-                "image": "quay.io/confidential-containers/reqs-payload:latest",
+                "image": "quay.io/confidential-containers/reqs-payload:6bba65f96532fa280b3996dcad2aad10bed777e6",
                 "volumeMounts": [
                   {
                     "mountPath": "/opt/confidential-containers/",
@@ -213,22 +224,27 @@ metadata:
               "runtimeClasses": [
                 {
                   "name": "kata-clh",
+                  "pulltype": "",
                   "snapshotter": "nydus"
                 },
                 {
                   "name": "kata-qemu",
+                  "pulltype": "",
                   "snapshotter": "nydus"
                 },
                 {
                   "name": "kata-qemu-tdx",
+                  "pulltype": "",
                   "snapshotter": "nydus"
                 },
                 {
                   "name": "kata-qemu-sev",
+                  "pulltype": "",
                   "snapshotter": "nydus"
                 },
                 {
                   "name": "kata-qemu-snp",
+                  "pulltype": "",
                   "snapshotter": "nydus"
                 }
               ],
@@ -246,11 +262,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Security
-    containerImage: quay.io/confidential-containers/operator:latest
-    createdAt: "2023-11-30T13:53:32Z"
+    containerImage: quay.io/confidential-containers/operator:v0.9.0
+    createdAt: "2024-08-06T14:14:00Z"
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: cc-operator.v0.8.0
+  name: cc-operator.v0.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -390,7 +406,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/confidential-containers/operator:v0.8.0
+                image: quay.io/confidential-containers/operator:v0.9.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -481,5 +497,5 @@ spec:
   provider:
     name: Confidential Containers Community
     url: https://github.com/confidential-containers
-  replaces: cc-operator.v0.5.0
-  version: 0.8.0
+  replaces: cc-operator.v0.8.0
+  version: 0.9.0

--- a/bundle/manifests/confidentialcontainers.org_ccruntimes.yaml
+++ b/bundle/manifests/confidentialcontainers.org_ccruntimes.yaml
@@ -5686,17 +5686,22 @@ spec:
                     description: This specifies the RuntimeClasses that need to be
                       created, with its name and an associated snapshotter to be used
                     items:
-                      description: RuntimeClass holds the name and the snapshotter
+                      description: RuntimeClass holds the name and basic customizations
                         to be used by a runtime class
                       properties:
                         name:
                           description: Name of the runtime class
+                          type: string
+                        pulltype:
+                          description: The pulling image method to be used by the
+                            runtime class
                           type: string
                         snapshotter:
                           description: The snapshotter to be used by the runtime class
                           type: string
                       required:
                       - name
+                      - pulltype
                       - snapshotter
                       type: object
                     type: array

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/confidential-containers/operator
-  newTag: latest
+  newTag: v0.9.0

--- a/config/manifests/bases/cc-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cc-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Security
-    containerImage: quay.io/confidential-containers/operator:latest
+    containerImage: quay.io/confidential-containers/operator:v0.9.0
   name: cc-operator.v0.0.1
   namespace: placeholder
 spec:
@@ -56,5 +56,5 @@ spec:
   provider:
     name: Confidential Containers Community
     url: https://github.com/confidential-containers
-  replaces: cc-operator.v0.5.0
+  replaces: cc-operator.v0.8.0
   version: 0.0.1

--- a/docs/OPERATOR_HUB.md
+++ b/docs/OPERATOR_HUB.md
@@ -34,7 +34,10 @@ Follow the steps:
 
 5. Copy the bundle directory to the community-operators repository directory. On the example below I got the community-operators repository cloned to `../../../github.com/k8s-operatorhub/community-operators`: 
    ```shell
-   cp -r bundle ../../../github.com/k8s-operatorhub/community-operators/operators/cc-operator/${TARGET_RELEASE}
+   dest_dir="../../../github.com/k8s-operatorhub/community-operators/operators/cc-operator/${TARGET_RELEASE}"
+   rm -rf "$dest_dir"
+   mkdir "$dest_dir"
+   cp -r bundle/* "$dest_dir"
    ```
 
 6. Prepare a commit and push to your tree


### PR DESCRIPTION
I submitted the https://github.com/k8s-operatorhub/community-operators/pull/4787 to publish 0.9.0 bundle in operator hub and coco's operator landing page in hub is already updated (see https://operatorhub.io/operator/cc-operator)

Here I'm sending the changes I did to publish it as well as a few fixes to docs.