### PR TITLE
ccruntime: Remove cleanup

### DIFF
--- a/bundle/manifests/cc-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cc-operator.clusterserviceversion.yaml
@@ -17,10 +17,6 @@ metadata:
               }
             },
             "config": {
-              "cleanupCmd": [
-                "/opt/kata-artifacts/scripts/kata-deploy.sh",
-                "reset"
-              ],
               "debug": false,
               "defaultRuntimeClassName": "kata-qemu",
               "environmentVariables": [

--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -49,7 +49,6 @@ spec:
         name: host
     installCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "install"]
     uninstallCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "cleanup"]
-    cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
     # Uncomment and add the required RuntimeClasses to be created
     # If this is commented, then the operator creates 3 default runtimeclasses "kata", "kata-clh", "kata-qemu"
     runtimeClasses: 

--- a/controllers/ccruntime_controller.go
+++ b/controllers/ccruntime_controller.go
@@ -604,12 +604,14 @@ func (r *CcRuntimeReconciler) processDaemonset(operation DaemonOperation) *appsv
 	preStopHook := &corev1.Lifecycle{}
 
 	if operation == InstallOperation {
-		preStopHook = &corev1.Lifecycle{
-			PreStop: &corev1.LifecycleHandler{
-				Exec: &corev1.ExecAction{
-					Command: r.ccRuntime.Spec.Config.CleanupCmd,
+		if r.ccRuntime.Spec.Config.CleanupCmd != nil {
+			preStopHook = &corev1.Lifecycle{
+				PreStop: &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{
+						Command: r.ccRuntime.Spec.Config.CleanupCmd,
+					},
 				},
-			},
+			}
 		}
 		containerCommand = r.ccRuntime.Spec.Config.InstallCmd
 	}

--- a/docs/PAYLOAD_IMAGE.md
+++ b/docs/PAYLOAD_IMAGE.md
@@ -59,7 +59,6 @@ Following is an example for Kata runtime depicting the key attributes.
         name: local-bin
     installCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "install"]
     uninstallCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "cleanup"]
-    cleanupCmd: ["/opt/kata-artifacts/scripts/kata-deploy.sh", "reset"]
 ```
 
 The installer (`/opt/kata-artifacts/scripts/kata-deploy.sh`) copies the required kata artifacts to


### PR DESCRIPTION
It's not needed anymore for the CC Runtime, as Kata Containers does the cleanup as part of the uninstall.

See: https://github.com/kata-containers/kata-containers/commit/8d9bec2e015f20126a84bc474e35ecf748f53d98

Calling the cleanup after calling the uninstall, which has already done the cleanup, could result on a infinite loop.