### PR TITLE
CI: Freeze kata-containers repo to workaround deploy bug

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -11,7 +11,8 @@ images:
   newTag: latest
 - name: quay.io/kata-containers/kata-deploy
   newName: quay.io/kata-containers/kata-deploy-ci
-  newTag: kata-containers-latest
+  # FIXME: Remove this once https://github.com/confidential-containers/operator/issues/391 is resolved
+  newTag: kata-containers-43dca8deb4891678f8a62c112749ac0938b373c6-amd64
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -11,7 +11,8 @@ images:
   newTag: latest
 - name: quay.io/kata-containers/kata-deploy
   newName: quay.io/kata-containers/kata-deploy-ci
-  newTag: kata-containers-latest
+  # FIXME: Remove this once https://github.com/confidential-containers/operator/issues/391 is resolved
+  newTag: kata-containers-43dca8deb4891678f8a62c112749ac0938b373c6-s390x
 
 patches:
 - patch: |-


### PR DESCRIPTION
the CI is currently blocked due to recent change in kata-containers as described here:

    https://github.com/confidential-containers/operator/issues/391

let's restore the testing with latest-known-to-work kata-containers to allow the CI to run