### PR TITLE
Revert "CI: Freeze kata-containers repo to workaround deploy bug"

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -11,8 +11,7 @@ images:
   newTag: latest
 - name: quay.io/kata-containers/kata-deploy
   newName: quay.io/kata-containers/kata-deploy-ci
-  # FIXME: Remove this once https://github.com/confidential-containers/operator/issues/391 is resolved
-  newTag: kata-containers-43dca8deb4891678f8a62c112749ac0938b373c6-amd64
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -11,8 +11,7 @@ images:
   newTag: latest
 - name: quay.io/kata-containers/kata-deploy
   newName: quay.io/kata-containers/kata-deploy-ci
-  # FIXME: Remove this once https://github.com/confidential-containers/operator/issues/391 is resolved
-  newTag: kata-containers-43dca8deb4891678f8a62c112749ac0938b373c6-s390x
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-


### PR DESCRIPTION
This reverts commit daec53827aca650613f06a53e85c25b54d4a3a92, as the issue with kata-deploy has been fixed.