### PR TITLE
ci: Start using the free GH runners for e2e testing

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -24,6 +24,8 @@ jobs:
         instance:
           - "az-ubuntu-2004"
           - "az-ubuntu-2204"
+          - "ubuntu-2004"
+          - "ubuntu-2204"
           - "s390x-large"
           - "tdx"
           - "sev"
@@ -68,6 +70,13 @@ jobs:
           args="-u"
           if [ $RUNNING_INSTANCE = "s390x-large" ]; then
             args=""
+          elif [ "$RUNNING_INSTANCE" == "ubuntu-2004" ] || [ "$RUNNING_INSTANCE" == "ubuntu-2204" ]; then
+            # Remove the pre-installed docker/containerd
+            sudo apt-get remove docker* containerd* -y
+            # Use /mnt to store images
+            sudo rm -Rf /var/lib/docker || true
+            sudo mkdir /mnt/docker || true
+            sudo ln -s /mnt/docker /var/lib/docker || true
           fi
           ./run-local.sh -t -r "${{ matrix.runtimeclass }}" "${args}"
         env:


### PR DESCRIPTION
the free-runners come with pre-installed containerd which sometimes collides with the one we install. We also need to move docker images to /mnt due to limitted root (/) partition.

Note I tried testing this on my fork https://github.com/ldoktor/coco-operator/pull/4 but for some reason I can only use `ubuntu-latest` while `ubuntu-2204` (which is the same as `ubuntu-latest`) fails, which is why I left the `az-*` runners on for now, we can remove them once the GH runners stabilize.