### PR TITLE
ci: Fix the GH free-runners label

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -24,8 +24,8 @@ jobs:
         instance:
           - "az-ubuntu-2004"
           - "az-ubuntu-2204"
-          - "ubuntu-2004"
-          - "ubuntu-2204"
+          - "ubuntu-20.04"
+          - "ubuntu-22.04"
           - "s390x-large"
           - "tdx"
           - "sev"


### PR DESCRIPTION
the reason GH is not picking up the jobs is a missing "." in the label name.