### PR TITLE
enable CodeQL checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Check updates to action versions in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week on Saturday
+      interval: "weekly"
+      day: "saturday"

--- a/.github/workflows/lib-codeql.yaml
+++ b/.github/workflows/lib-codeql.yaml
@@ -1,0 +1,35 @@
+name: "CodeQL"
+
+on:
+  workflow_call:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analysis
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+
+    permissions:
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+    - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
+      with:
+        go-version-file: go.mod
+        check-latest: true
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@2c779ab0d087cd7fe7b826087247c2c81f27bfa6 # v3
+      with:
+        languages: 'go'
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@2c779ab0d087cd7fe7b826087247c2c81f27bfa6 # v3
+      with:
+        category: "/language:go"

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
       with:
         go-version-file: go.mod
         check-latest: true
@@ -34,3 +34,12 @@ jobs:
 
     - name: Build bundle
       run: make bundle IMG=quay.io/confidential-containers/operator:latest
+
+  codeql:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    needs:
+      - build
+    uses: "./.github/workflows/lib-codeql.yaml"


### PR DESCRIPTION
This PR is a reference for few improvements in our repositories

1. enable dependabot github-actions updates using pinned versions (dependabot understands pinned versions nowadays). Pinned versions are considered safe since attackers could re-push tags. The move to pinned versions must be done manually.
2. enable CodeQL checks for our Go based code (to be checked: maintainers might have to enable this in the repo settings also)

Ref: https://github.com/confidential-containers/confidential-containers/issues/46