### PR TITLE
ci: GH runners fixes

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -70,7 +70,7 @@ jobs:
           args="-u"
           if [ $RUNNING_INSTANCE = "s390x-large" ]; then
             args=""
-          elif [ "$RUNNING_INSTANCE" == "ubuntu-2004" ] || [ "$RUNNING_INSTANCE" == "ubuntu-2204" ]; then
+          elif [ "$RUNNING_INSTANCE" == "ubuntu-20.04" ] || [ "$RUNNING_INSTANCE" == "ubuntu-22.04" ]; then
             # Remove the pre-installed docker/containerd
             sudo apt-get remove docker* containerd* -y
             # Use /mnt to store images

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -99,6 +99,8 @@ The following jobs will check for regessions on the default CcRuntime:
 |e2e-pr / operator tests (kata-qemu, s390x) | Non-TEE | Ubuntu 22.04 (s390x) | QEMU |
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2004) | Non-TEE |  Ubuntu 20.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu, az-ubuntu-2204) | Non-TEE |  Ubuntu 22.04 | QEMU |
+|e2e-pr / operator tests (kata-qemu, ubuntu-20.04) | Non-TEE |  Ubuntu 20.04 | QEMU |
+|e2e-pr / operator tests (kata-qemu, ubuntu-22.04) | Non-TEE |  Ubuntu 22.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu-tdx, tdx) | TDX |  Ubuntu 24.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu-sev, coco-ci-amd-rome-001, ) | SEV |  Ubuntu 22.04 | QEMU |
 |e2e-pr / operator tests (kata-qemu-snp, coco-ci-amd-milan-001) | SNP |  Ubuntu 22.04 | QEMU |


### PR DESCRIPTION
The first commit fixes the workflow after the instance name changed to contain `.` in the version. The second commit adds the new jobs to the CI documentation.