### PR TITLE
ci: Remove azure-based workers pipelines

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -22,8 +22,6 @@ jobs:
         runtimeclass:
           - "kata-qemu"
         instance:
-          - "az-ubuntu-2004"
-          - "az-ubuntu-2204"
           - "ubuntu-20.04"
           - "ubuntu-22.04"
           - "s390x-large"


### PR DESCRIPTION
the github free-runners seem to perform well and stable, let's disable the azure runners.