### PR TITLE
ci: Always run e2e testing

### DIFF
--- a/.github/workflows/ccruntime-pr.yaml
+++ b/.github/workflows/ccruntime-pr.yaml
@@ -8,8 +8,6 @@ on:
       - synchronize
       - reopened
       - labeled
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   e2e-pr:


### PR DESCRIPTION
the "e2e-pr / operator tests" is always required so we have to run it even though it does not make much sense.

This should help with https://github.com/confidential-containers/operator/pull/444