### PR TITLE
Revert "ci: Remove tdx CI jobs temporarily"

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -25,6 +25,7 @@ jobs:
           - "ubuntu-20.04"
           - "ubuntu-22.04"
           - "s390x-large"
+          - "tdx"
           - "sev"
           - "sev-snp"
         exclude:
@@ -35,6 +36,8 @@ jobs:
           - runtimeclass: "kata-qemu"
             instance: "sev-snp"
         include:
+          - runtimeclass: "kata-qemu-tdx"
+            instance: "tdx"
           - runtimeclass: "kata-qemu-sev"
             instance: "sev"
           - runtimeclass: "kata-qemu-snp"


### PR DESCRIPTION
This reverts commit a1a68e01c15d7b010fc0b3b610eef33452f584d6, as the TDX machine is back online.