### PR TITLE
Fix warning on the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG IMG_NAME
 ARG IMG_VERSION
 
 # Build the manager binary
-FROM ${IMG_NAME:-golang}:${IMG_VERSION:-1.22} as builder
+FROM ${IMG_NAME:-golang}:${IMG_VERSION:-1.22} AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
This PR fixes the warning of 'FromAsCasing: 'as and FROM keywords casing do not match' when building the Dockerfile.