### PR TITLE
Fix warning in Dockerfile.peerpods

### DIFF
--- a/Dockerfile.peerpods
+++ b/Dockerfile.peerpods
@@ -4,7 +4,7 @@ ARG IMG_NAME
 ARG IMG_VERSION
 
 # Build the manager binary
-FROM ${IMG_NAME:-golang}:${IMG_VERSION:-1.22} as builder
+FROM ${IMG_NAME:-golang}:${IMG_VERSION:-1.22} AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
While building this Dockerfile we got the following warning 'FromAsCasing: as and FROM keywords casing do not match', this PR fixes it.