### PR TITLE
actions: Build only current arch in e2e testing

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -66,8 +66,10 @@ jobs:
           cd tests/e2e
           export PATH="$PATH:/usr/local/bin"
           args="-u"
+          export pre_install_payload_archs="linux/amd64"
           if [ $RUNNING_INSTANCE = "s390x-large" ]; then
             args=""
+            export pre_install_payload_archs="linux/s390x"
           elif [ "$RUNNING_INSTANCE" == "ubuntu-20.04" ] || [ "$RUNNING_INSTANCE" == "ubuntu-22.04" ]; then
             # Remove the pre-installed docker/containerd
             sudo apt-get remove docker* containerd* -y

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -11,14 +11,9 @@ official_containerd_repo=${official_containerd_repo:-"https://github.com/contain
 vfio_gpu_containerd_repo=${vfio_gpu_containerd_repo:-"https://github.com/confidential-containers/containerd"}
 nydus_snapshotter_repo=${nydus_snapshotter_repo:-"https://github.com/containerd/nydus-snapshotter"}
 extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
+archs=${pre_install_payload_archs:-"linux/amd64 linux/s390x linux/arm64"}
 
 registry="${registry:-quay.io/confidential-containers/reqs-payload}"
-
-supported_arches=(
-	"linux/amd64"
-	"linux/s390x"
-	"linux/arm64"
-)
 
 function setup_env_for_arch() {
 	case "$1" in
@@ -58,7 +53,7 @@ function build_payload() {
 	tag=$(git rev-parse HEAD)
 
 	manifest_args=()
-	for arch in "${supported_arches[@]}"; do
+	for arch in ${archs}; do
 		setup_env_for_arch "${arch}"
 
 		echo "Building containerd payload image for ${arch}"


### PR DESCRIPTION
Currently the pre-install-payload builds always all supported payload archs. Let's allow tweaking this by "pre_install_payload_archs" environment variable and use that in our e2e pipelines to only build the current architecture.

Related to: https://github.com/confidential-containers/operator/pull/474#pullrequestreview-2506389242