### PR TITLE
ci: Fix unintended loop behavior when checking docker registry health

### DIFF
--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -230,9 +230,9 @@ start_local_registry() {
 	if ! curl -s localhost:5000; then
 		docker start "$registry_container" >/dev/null
 		local cnt=0
-		while ! curl -s localhost:5000 -o $cnt -lt 5; do
+		while ! curl -s localhost:5000 && [ $cnt -lt 5 ]; do
 			sleep 1
-			cnt=$(($cnt+1))
+			cnt=$((cnt + 1))
 		done
 		[ $cnt -ne 5 ]
 	fi


### PR DESCRIPTION
The existing condition in the `start_local_registry` function does not work as expected:

```
while ! curl -s localhost:5000 -o $cnt -lt 5; do
```

This could result in an infinite loop because the curl return value is not correctly combined with the counter condition. Instead of exiting after 5 retries, the loop increments $cnt indefinitely as long as curl fails, as shown:

```
+ cnt=5
+ curl -s localhost:5000 -o 5 -lt 5
+ sleep 1
+ cnt=6
+ curl -s localhost:5000 -o 6 -lt 5
+ sleep 1
+ cnt=7
+ curl -s localhost:5000 -o 7 -lt 5
+ sleep 1
```

Additionally, `-o $cnt -lt 5` can be misinterpreted as an argument for curl, further compounding the issue.

This PR resolves the misbehavior by:
1.  Properly combining conditions with &&
2.  Incrementing $cnt in a modern bash style

The corrected logic is aligned with the intended behavior. It ensures the loop exits after 5 retries or when the registry becomes accessible

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>