### PR TITLE
tests: Wait for stabilization after deployment

### DIFF
--- a/tests/e2e/operator_tests.bats
+++ b/tests/e2e/operator_tests.bats
@@ -42,6 +42,9 @@ systemctl is-active "$container_runtime"
 ! is_operator_installed
 
 "${BATS_TEST_DIRNAME}/operator.sh" install
+
+# Wait for the deployment to be stable
+"${BATS_TEST_DIRNAME}/operator.sh" wait_for_stabilization
 }
 
 teardown() {


### PR DESCRIPTION
the operator reinstall test only installs the runtime and finishes. This can cause issues in consequent tests or in cleanup as was observed in the CI (hang in cleanup after quick deployment).