### PR TITLE
install: several fixes to avoid containerd config file corruption

### DIFF
--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -195,8 +195,11 @@ function configure_nydus_snapshotter_for_containerd() {
 	address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 EOF
 		if grep -q "^imports = " "$tmp_containerd_config"; then
-			sed -i -e "s|^imports = \[\(.*\)\]|imports = [\"${containerd_imports_path}/nydus-snapshotter.toml\", \1]|g" "${tmp_containerd_config}"
-			sed -i -e "s|, ]|]|g" "${tmp_containerd_config}"
+			# Avoid adding the import twice
+			if ! grep "^imports = " "$tmp_containerd_config" | grep -q "\"${containerd_imports_path}/nydus-snapshotter.toml\""; then
+				sed -i -e "s|^imports = \[\(.*\)\]|imports = [\"${containerd_imports_path}/nydus-snapshotter.toml\", \1]|g" "${tmp_containerd_config}"
+				sed -i -e "s|, ]|]|g" "${tmp_containerd_config}"
+			fi
 		else
 			sed -i -e "1s|^|imports = [\"${containerd_imports_path}/nydus-snapshotter.toml\"]\n|" "${tmp_containerd_config}"
 		fi

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -84,8 +84,6 @@ function install_nydus_snapshotter_artefacts() {
 	host_systemctl enable nydus-snapshotter.service
 
 	configure_nydus_snapshotter_for_containerd
-
-	restart_systemd_service
 }
 
 function install_artifacts() {
@@ -119,8 +117,6 @@ function uninstall_containerd_artefacts() {
 		rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${container_engine}.service.d"
 	fi
 
-	restart_systemd_service
-
 	echo "Removing the containerd binary"
 	rm -f /opt/confidential-containers/bin/containerd
 	echo "Removing the /opt/confidential-containers/bin directory"
@@ -138,8 +134,6 @@ function uninstall_nydus_snapshotter_artefacts() {
 		remove_nydus_snapshotter_from_containerd
 		host_systemctl disable --now nydus-snapshotter.service
 		rm -rf /etc/systemd/system/nydus-snapshotter.service
-
-		restart_systemd_service
 	fi
 
 	echo "Removing nydus-snapshotter artifacts from host"
@@ -308,7 +302,6 @@ function main() {
 	case "${action}" in
 	install)
 		install_artifacts
-		restart_systemd_service
 		;;
 	uninstall)
 		# Adjustment for s390x (clefos:7)
@@ -325,6 +318,7 @@ function main() {
 		;;
 	esac
 
+	restart_systemd_service
 	label_node "${action}"
 
 

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -270,6 +270,15 @@ label_node() {
 	esac
 }
 
+function wait_till_node_is_ready() {
+    local ready="False"
+
+    while ! [[ "${ready}" == "True" ]]; do
+        sleep 2s
+        ready=$(kubectl get node $NODE_NAME -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    done
+}
+
 function print_help() {
 	echo "Help: ${0} [install/uninstall]"
 }
@@ -319,6 +328,7 @@ function main() {
 	esac
 
 	restart_systemd_service
+	wait_till_node_is_ready
 	label_node "${action}"
 
 

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -238,7 +238,6 @@ function remove_nydus_snapshotter_from_containerd() {
         local containerd_config_pre="$(cat "${containerd_config}")"
         echo "${containerd_config_pre}" > "$tmp_containerd_config"
 
-		rm -f "${containerd_imports_path}/nydus-snapshotter.toml"
 		sed -i -e "s|\"${containerd_imports_path}/nydus-snapshotter.toml\"||g" "${tmp_containerd_config}"
 		sed -i -e "s|, ]|]|g" "${tmp_containerd_config}"
 
@@ -258,6 +257,7 @@ function remove_nydus_snapshotter_from_containerd() {
 		sleep $(($RANDOM / 1000))
 	done ) || { echo "Failed to unconfigure snapshotter in 10 iterations, is someone else modifying the config?"; exit -1; }
 	rm -f "$tmp_containerd_config"
+	rm -f "${containerd_imports_path}/nydus-snapshotter.toml"
 }
 
 label_node() {


### PR DESCRIPTION
The corruption seems to be mainly caused by double-execution of the pre-reqs setup. This part should avoid the corruption but it still might collide with kata-deploy as the operator currently uses the same label to start cleanup and to detect the cleanup is done. This should be handled separately later...

Fixes #481