### PR TITLE
Several changes to cc operator labels

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -81,6 +81,8 @@ jobs:
             sudo rm -Rf $HOME/go || true
             sudo mkdir /mnt/go || true
             sudo ln -s /mnt/go $HOME/go || true
+            # Remove bunch of preinstalled things we don't use
+            sudo rm /usr/local/share/ -Rf || true
             if [ "$RUNNING_INSTANCE" == "ubuntu-22.04-arm" ] || [ "$RUNNING_INSTANCE" == "arm64-nvidia-gpu" ]; then
               export pre_install_payload_archs="linux/arm64"
             fi

--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -77,6 +77,13 @@ jobs:
             sudo rm -Rf /var/lib/docker || true
             sudo mkdir /mnt/docker || true
             sudo ln -s /mnt/docker /var/lib/docker || true
+            # Use /mnt/go for GOPATH
+            sudo rm -Rf $HOME/go || true
+            sudo mkdir /mnt/go || true
+            sudo ln -s /mnt/go $HOME/go || true
+            if [ "$RUNNING_INSTANCE" == "ubuntu-22.04-arm" ] || [ "$RUNNING_INSTANCE" == "arm64-nvidia-gpu" ]; then
+              export pre_install_payload_archs="linux/arm64"
+            fi
           fi
           ./run-local.sh -t -r "${{ matrix.runtimeclass }}" "${args}"
         env:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -8,9 +8,9 @@ import (
 type DaemonOperation string
 
 var (
-	PreInstallDoneLabel    = []string{"cc-preinstall/done", "true"}
-	PostUninstallDoneLabel = []string{"cc-postuninstall/done", "true"}
-	StartUninstallLabel    = []string{"cc-startuninstall/done", "true"}
+	PreInstallDoneLabel    = []string{"confidentialcontainers.org/preinstall", "done"}
+	PostUninstallDoneLabel = []string{"confidentialcontainers.org/postuninstall", "done"}
+	StartUninstallLabel    = []string{"confidentialcontainers.org/startuninstall", "true"}
 )
 
 const (

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -10,7 +10,7 @@ type DaemonOperation string
 var (
 	PreInstallDoneLabel    = []string{"cc-preinstall/done", "true"}
 	PostUninstallDoneLabel = []string{"cc-postuninstall/done", "true"}
-	KataRuntimeLabel       = []string{"katacontainers.io/kata-runtime", "cleanup"}
+	StartUninstallLabel    = []string{"cc-startuninstall/done", "true"}
 )
 
 const (

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -195,8 +195,11 @@ function configure_nydus_snapshotter_for_containerd() {
 	address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 EOF
 		if grep -q "^imports = " "$tmp_containerd_config"; then
-			sed -i -e "s|^imports = \[\(.*\)\]|imports = [\"${containerd_imports_path}/nydus-snapshotter.toml\", \1]|g" "${tmp_containerd_config}"
-			sed -i -e "s|, ]|]|g" "${tmp_containerd_config}"
+			# Avoid adding the import twice
+			if ! grep "^imports = " "$tmp_containerd_config" | grep -q "\"${containerd_imports_path}/nydus-snapshotter.toml\""; then
+				sed -i -e "s|^imports = \[\(.*\)\]|imports = [\"${containerd_imports_path}/nydus-snapshotter.toml\", \1]|g" "${tmp_containerd_config}"
+				sed -i -e "s|, ]|]|g" "${tmp_containerd_config}"
+			fi
 		else
 			sed -i -e "1s|^|imports = [\"${containerd_imports_path}/nydus-snapshotter.toml\"]\n|" "${tmp_containerd_config}"
 		fi

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -84,8 +84,6 @@ function install_nydus_snapshotter_artefacts() {
 	host_systemctl enable nydus-snapshotter.service
 
 	configure_nydus_snapshotter_for_containerd
-
-	restart_systemd_service
 }
 
 function install_artifacts() {
@@ -119,8 +117,6 @@ function uninstall_containerd_artefacts() {
 		rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${container_engine}.service.d"
 	fi
 
-	restart_systemd_service
-
 	echo "Removing the containerd binary"
 	rm -f /opt/confidential-containers/bin/containerd
 	echo "Removing the /opt/confidential-containers/bin directory"
@@ -138,8 +134,6 @@ function uninstall_nydus_snapshotter_artefacts() {
 		remove_nydus_snapshotter_from_containerd
 		host_systemctl disable --now nydus-snapshotter.service
 		rm -rf /etc/systemd/system/nydus-snapshotter.service
-
-		restart_systemd_service
 	fi
 
 	echo "Removing nydus-snapshotter artifacts from host"
@@ -308,7 +302,6 @@ function main() {
 	case "${action}" in
 	install)
 		install_artifacts
-		restart_systemd_service
 		;;
 	uninstall)
 		# Adjustment for s390x (clefos:7)
@@ -325,6 +318,7 @@ function main() {
 		;;
 	esac
 
+	restart_systemd_service
 	label_node "${action}"
 
 

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -260,10 +260,10 @@ function remove_nydus_snapshotter_from_containerd() {
 label_node() {
 	case "${1}" in
 	install)
-		kubectl label node "${NODE_NAME}" cc-preinstall/done=true
+		kubectl label node "${NODE_NAME}" confidentialcontainers.org/preinstall=done
 		;;
 	uninstall)
-		kubectl label node "${NODE_NAME}" cc-postuninstall/done=true
+		kubectl label node "${NODE_NAME}" confidentialcontainers.org/postuninstall=done
 		;;
 	*)
 		;;

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -270,6 +270,15 @@ label_node() {
 	esac
 }
 
+function wait_till_node_is_ready() {
+    local ready="False"
+
+    while ! [[ "${ready}" == "True" ]]; do
+        sleep 2s
+        ready=$(kubectl get node $NODE_NAME -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    done
+}
+
 function print_help() {
 	echo "Help: ${0} [install/uninstall]"
 }
@@ -319,6 +328,7 @@ function main() {
 	esac
 
 	restart_systemd_service
+	wait_till_node_is_ready
 	label_node "${action}"
 
 

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -238,7 +238,6 @@ function remove_nydus_snapshotter_from_containerd() {
         local containerd_config_pre="$(cat "${containerd_config}")"
         echo "${containerd_config_pre}" > "$tmp_containerd_config"
 
-		rm -f "${containerd_imports_path}/nydus-snapshotter.toml"
 		sed -i -e "s|\"${containerd_imports_path}/nydus-snapshotter.toml\"||g" "${tmp_containerd_config}"
 		sed -i -e "s|, ]|]|g" "${tmp_containerd_config}"
 
@@ -258,6 +257,7 @@ function remove_nydus_snapshotter_from_containerd() {
 		sleep $(($RANDOM / 1000))
 	done ) || { echo "Failed to unconfigure snapshotter in 10 iterations, is someone else modifying the config?"; exit -1; }
 	rm -f "$tmp_containerd_config"
+	rm -f "${containerd_imports_path}/nydus-snapshotter.toml"
 }
 
 label_node() {

--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -132,29 +132,32 @@ install_ccruntime() {
 	kubectl create -k .
 	popd >/dev/null
 
-	local pod=""
-	local cmd=""
-	for pod in cc-operator-daemon-install cc-operator-pre-install-daemon; do
-		cmd="kubectl get pods -n '$op_ns' --no-headers |"
-		cmd+="egrep -q ${pod}.*'\<Running\>'"
-		if ! wait_for_process 600 30 "$cmd"; then
-			echo "::error:: $pod pod is not running"
-			local pod_id
-			pod_id="$(get_pods_regex "$pod" "$op_ns")"
-			echo "::debug:: Pod $pod_id"
-			debug_pod "$pod_id" "$op_ns"
+	# Wait for the operator to report installationStatus.completed on all nodes
+	local count=0
+	local nodes
 
+	while true; do
+		nodes="$(kubectl get ccruntime -o jsonpath='{range .items[*]}{.status.totalNodesCount}{end}')" || nodes=-1
+		if [ "$nodes" -gt 0 ] 2>/dev/null; then
+			[ "$(kubectl get ccruntime -o jsonpath='{range .items[*]}{.status.installationStatus.completed.completedNodesCount}{end}')" -eq "$nodes" ] 2>/dev/null && break || true
+		fi
+		((count+=1))
+		if [ $count -gt 600 ]; then
+			echo "::error:: cc runtime not installed in $count iterations ($nodes, $(kubectl get ccruntime -o jsonpath='{range .items[*]}{.status.installationStatus.completed.completedNodesCount}{end}'))"
+			kubectl describe ccruntime
 			return 1
 		fi
+		sleep 1
 	done
 
-	# Check if the runtime is up.
-	# There could be a case where it is not even if the pods above are running.
+	# Check if runtimeclass is available
 	local cmd="kubectl get runtimeclass | grep -q ${runtimeclass}"
-	if ! wait_for_process 300 30 "$cmd"; then
+	if ! wait_for_process 30 1 "$cmd"; then
 		echo "::error:: runtimeclass ${runtimeclass} is not up"
+		kubectl get runtimeclass
 		return 1
 	fi
+
 	# To keep operator running, we should resume registry stopped during containerd restart.
 	start_local_registry
 }

--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -189,7 +189,7 @@ uninstall_ccruntime() {
 
 	echo "::debug:: labels in worker should be gone"
 	if kubectl get nodes "$SAFE_HOST_NAME" -o jsonpath='{.metadata.labels}' | \
-		grep -q -e cc-preinstall -e katacontainers.io; then
+		grep -q -e confidentialcontainers.org -e katacontainers.io; then
 		echo "::error:: there are labels left behind"
 		kubectl get nodes "$SAFE_HOST_NAME" -o jsonpath='{.metadata.labels}'
 

--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -124,7 +124,7 @@ install_ccruntime() {
 	local overlay_dir="${ccruntime_overlay_basedir}/${ccruntime_overlay}"
 
 	# Use the built pre-install image
-	kustomization_set_image  "${ccruntime_overlay_basedir}/default" \
+	kustomization_set_image  "${ccruntime_overlay_basedir}/${ccruntime_overlay}" \
 		"quay.io/confidential-containers/reqs-payload" \
 		"${PRE_INSTALL_IMG}"
 


### PR DESCRIPTION
This is a 2nd stage of https://github.com/confidential-containers/operator/pull/482 which adds a new node label to be used as nodeSelector for daemon uninstall and removes the hardcoded 60s sleep. On top it also re-names the labels which might be invasive right now but should be aligned to how kata uses labels. Take this as a suggestion open to negotiation :-)