### PR TITLE
ci: Enable ccruntime-e2e and makefile test on arm64

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -28,6 +28,7 @@ jobs:
           - "tdx"
           - "sev"
           - "sev-snp"
+          - "ubuntu-22.04-arm"
         exclude:
           - runtimeclass: "kata-qemu"
             instance: "tdx"
@@ -70,7 +71,7 @@ jobs:
           if [ $RUNNING_INSTANCE = "s390x-large" ]; then
             args=""
             export pre_install_payload_archs="linux/s390x"
-          elif [ "$RUNNING_INSTANCE" == "ubuntu-20.04" ] || [ "$RUNNING_INSTANCE" == "ubuntu-22.04" ]; then
+          elif [[ "$RUNNING_INSTANCE" == "ubuntu-"* ]] || [[ "$RUNNING_INSTANCE" == "arm64-nvidia-gpu" ]]; then
             # Remove the pre-installed docker/containerd
             sudo apt-get remove docker* containerd* -y
             # Use /mnt to store images

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -9,7 +9,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        instance:
+          - "ubuntu-22.04"
+          - "ubuntu-22.04-arm"
+    runs-on: ${{ matrix.instance }}
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
@@ -43,13 +48,16 @@ jobs:
 
   envtest:
     name: Test APIs using envtest
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
+        instance:
+          - "ubuntu-22.04"
+          - "ubuntu-22.04-arm"
         version:
           - 1.30.x
           - 1.31.x
           - 1.32.x
+    runs-on: ${{ matrix.instance }}
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5


### PR DESCRIPTION
This changes enables e2e and makefile test on arm64 runner. There are some prerequisite.

Ther operator's CI is as following: (${\color{red}red}$ parts are added by this change)
* ccruntime-nightly (executed at 02:00 everyday)
  * call ccruntime-e2e (e2e test on amd64, s390x, ${\color{red}arm64}$)
* ccruntime-pr (exectued at pull request)
  * call ccruntime-e2e (e2e test on amd64, s390x, ${\color{red}arm64}$)
* docker-publish-latest-on-merge (build images on amd64)
* docker-publish-on-tag (build images on amd64)
* enclave-cc-cicd (sgx specific test on amd64)
* enclave-cc-e2e (sgx specific test on amd64)
* gofmt (lint on amd64)
* golangci-lint (lint on amd64)
* makefile
  * build test on amd64, ${\color{red}arm64}$
  * lib-codeql (static analysis on amd64)
  * envtest on amd64, ${\color{red}arm64}$