### PR TITLE
test: Deploy local ccruntime for s390x

### DIFF
--- a/tests/e2e/operator.sh
+++ b/tests/e2e/operator.sh
@@ -124,7 +124,7 @@ install_ccruntime() {
 	local overlay_dir="${ccruntime_overlay_basedir}/${ccruntime_overlay}"
 
 	# Use the built pre-install image
-	kustomization_set_image  "${ccruntime_overlay_basedir}/default" \
+	kustomization_set_image  "${ccruntime_overlay_basedir}/${ccruntime_overlay}" \
 		"quay.io/confidential-containers/reqs-payload" \
 		"${PRE_INSTALL_IMG}"
 


### PR DESCRIPTION
`quay.io/confidential-containers/reqs-payload` has been used for ccruntime for s390x because `config/sample/default/kustomization.yaml` is patched. This is only valid for x86_64, but s390x.
It should be `config/sample/${ccruntime_overlay}/kustomization.yaml`. Let's use a local image for the platform.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>