### PR TITLE
tests/e2e: Fix systemd path handling for Ubuntu 24.04 on s390x

### DIFF
--- a/tests/e2e/ansible/install_docker.yaml
+++ b/tests/e2e/ansible/install_docker.yaml
@@ -108,8 +108,8 @@
         - name: Copy fragment file to /etc/systemd/system/docker.service.d
           copy:
             src: "{{ fragment_path.stdout }}"
-            dest: "{{ fragment_path.stdout.replace('/lib', '/etc') }}"
-          when: fragment_path.stdout.find('/lib') != -1
+            dest: /etc/systemd/system/docker.service
+          when: fragment_path.stdout.startswith(('/lib', '/usr/lib'))
     - name: Configure `StartLimitBurst=0` in /etc/systemd/system/docker.service
       block:
         - name: Check if /etc/systemd/system/docker.service has StartLimitBurst=0


### PR DESCRIPTION
When upgrading the s390x runner to Ubuntu 24.04, the following error occurred:

```
Destination directory /usr/etc/systemd/system does not exist
```

Previously, the script replaced `/lib` with `/etc` in systemd paths. However, on Ubuntu 24.04, `systemctl show -p FragmentPath docker.service` returns `/usr/lib/systemd/system/docker.service`, rendering the old substitution invalid.
This PR updates the destination directory to
`/etc/systemd/system/docker.service` and fulfills the copy logic if the fragment path starts with either `/lib` or `/usr/lib`.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>