### PR TITLE
dependabot: Group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions monthly, on the first day of the month
       interval: "monthly"
+    groups:
+      # Group PRs
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
this should group all dependabot PRs, which should decrease the amount of CI and acks for GH action version changes.