### PR TITLE
tests: Send -9 on cleanup interruption

### DIFF
--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -49,7 +49,7 @@ parse_args() {
 run() {
 	duration=$1; shift
 	if [ "$timeout" == "true" ]; then
-		timeout $duration "$@"
+		timeout -v -s 9 $duration "$@"
 	else
 		"$@"
 	fi


### PR DESCRIPTION
we are using "timeout" to limit cleanup time in CI, but the default -15 won't interrupt on some occasions. Let's use -9 instead to not to block in case the cleanup fails.

Note this is only about the cleanup part of the e2e run-local.sh, every hang inside the testing itself should still result in a failure.