### PR TITLE
ci: Replace deprecated GH ubuntu 20.04 for 24.04

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -22,8 +22,8 @@ jobs:
         runtimeclass:
           - "kata-qemu"
         instance:
-          - "ubuntu-20.04"
           - "ubuntu-22.04"
+          - "ubuntu-24.04"
           - "s390x-large"
           - "tdx"
           - "sev-snp"


### PR DESCRIPTION
the ubuntu 20.04 is deprecated and removed from GH runners, let's replace it with the latest 24.04 to ensure various versions keep working well.