### PR TITLE
Release: Revert v0.14.0 release-specfic changes back to dev values

### DIFF
--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,9 +8,10 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad2b8ea64b919d977b1d3fab488333283ea05d9
+  newTag: latest
 - name: quay.io/kata-containers/kata-deploy
-  newTag: 3.17.0
+  newName: quay.io/kata-containers/kata-deploy-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -9,9 +9,10 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad2b8ea64b919d977b1d3fab488333283ea05d9
+  newTag: latest
 - name: quay.io/kata-containers/kata-deploy
-  newTag: 3.17.0
+  newName: quay.io/kata-containers/kata-deploy-ci
+  newTag: kata-containers-latest
 
 
 patches:

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -8,9 +8,10 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad2b8ea64b919d977b1d3fab488333283ea05d9
+  newTag: latest
 - name: quay.io/kata-containers/kata-deploy
-  newTag: 3.17.0
+  newName: quay.io/kata-containers/kata-deploy-ci
+  newTag: kata-containers-latest
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-cc-kbc-v0.11.0
+    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-latest
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -8,4 +8,4 @@ nameSuffix: -sgx-mode-hw
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad2b8ea64b919d977b1d3fab488333283ea05d9
+  newTag: latest

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload
-  newTag: enclave-cc-SIM-sample-kbc-v0.11.0
+- name: quay.io/confidential-containers/runtime-payload-ci
+  newTag: enclave-cc-SIM-sample-kbc-latest
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: 4ad2b8ea64b919d977b1d3fab488333283ea05d9
+  newTag: latest


### PR DESCRIPTION
It reverts the changes done in two commits (related to the kata payloads and enclave-cc payloads) with the PR #525 .