### PR TITLE
e2e: run tdx operator tests on ubuntu-24.04 runner

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -25,17 +25,14 @@ jobs:
           - "ubuntu-22.04"
           - "ubuntu-24.04"
           - "s390x-large"
-          - "tdx"
           - "sev-snp"
           - "ubuntu-22.04-arm"
         exclude:
           - runtimeclass: "kata-qemu"
-            instance: "tdx"
-          - runtimeclass: "kata-qemu"
             instance: "sev-snp"
         include:
           - runtimeclass: "kata-qemu-tdx"
-            instance: "tdx"
+            instance: "ubuntu-24.04"
           - runtimeclass: "kata-qemu-snp"
             instance: "sev-snp"
     runs-on: ${{ matrix.instance }}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,17 +98,16 @@ This is a list of the bare-metal machines and VMs that are utilized by the proje
 | ---                   | ---        | ---            | ---                                      |
 | s390x-runner-01       | virtual    | Non-TEE        | s390x, s390x-large                       |
 | s390x-runner-02       | virtual    | Non-TEE        | s390x                                    |
-| tdx-ubuntu-24.04      | bare-metal | TDX            | self-hosted, Linux, X64, tdx             |
 | coco-ci-amd-milan-001 | bare-metal | SNP            | self-hosted, Linux, X64, sev-snp, sev-es |
 
 The following jobs will check for regressions on the default CcRuntime:
 
 | Job Name                                          | TEE     | OS           | VMM  | runs-on      |
 | ---                                               | ---     | ---          | ---  | ---          |
-| e2e-pr / operator tests (kata-qemu, ubuntu-20.04) | Non-TEE | Ubuntu 20.04 | QEMU | ubuntu-20.04 |
 | e2e-pr / operator tests (kata-qemu, ubuntu-22.04) | Non-TEE | Ubuntu 22.04 | QEMU | ubuntu-22.04 |
+| e2e-pr / operator tests (kata-qemu, ubuntu-24.04) | Non-TEE | Ubuntu 24.04 | QEMU | ubuntu-24.04 |
 | e2e-pr / operator tests (kata-qemu, s390x-large)  | Non-TEE | Ubuntu 22.04 | QEMU | s390x-large  |
-| e2e-pr / operator tests (kata-qemu-tdx, tdx)      | TDX     | Ubuntu 24.04 | QEMU | tdx          |
+| e2e-pr / operator tests (kata-qemu-tdx, ubuntu-24.04) | TDX     | Ubuntu 24.04 | QEMU | ubuntu-24.04 |
 | e2e-pr / operator tests (kata-qemu-snp, sev-snp)  | SNP     | Ubuntu 22.04 | QEMU | sev-snp      |
 
 The 'runs-on' entries above define which machine a job will land on by matching the machine's assigned labels.


### PR DESCRIPTION
kata-deploy supports Ubuntu 24.04 (and 25.04) based TDX enablement. Since the operator e2e does not test any TEE specifics, it's enough to test that kata-qemu-tdx runtimeclass gets created on a vanilla Ubuntu 24.04.