### PR TITLE
Release: Update payloads for v0.16.0

### DIFF
--- a/.github/workflows/ccruntime_e2e.yaml
+++ b/.github/workflows/ccruntime_e2e.yaml
@@ -44,6 +44,29 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
+      - name: Remove unnecessary directories to free up space
+        run: |
+          if [[ "$RUNNING_INSTANCE" == "ubuntu-"* ]]; then
+            sudo rm -rf /usr/local/.ghcup
+            sudo rm -rf /opt/hostedtoolcache/CodeQL
+            sudo rm -rf /usr/local/lib/android
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf /opt/ghc
+            sudo rm -rf /usr/local/share/boost
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+            sudo rm -rf /usr/lib/jvm
+            sudo rm -rf /usr/share/swift
+            sudo rm -rf /usr/local/share/powershell
+            sudo rm -rf /usr/local/julia*
+            sudo rm -rf /opt/az
+            sudo rm -rf /usr/local/share/chromium
+            sudo rm -rf /opt/microsoft
+            sudo rm -rf /opt/google
+            sudo rm -rf /usr/lib/firefox
+          fi
+        env:
+          RUNNING_INSTANCE: ${{ matrix.instance }}
+
       - name: Install deps
         run: |
           sudo apt-get update -y

--- a/config/release/kustomization.yaml
+++ b/config/release/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 # newTag points to the latest release image and must be updated before tagging a new release
 images:
 - name: quay.io/confidential-containers/operator
-  newTag: v0.15.0
+  newTag: v0.16.0

--- a/config/samples/ccruntime/default/kustomization.yaml
+++ b/config/samples/ccruntime/default/kustomization.yaml
@@ -8,10 +8,9 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: latest
+  newTag: 6fa876bea238c4ba08af0f9b1a696f28c834e84f
 - name: quay.io/kata-containers/kata-deploy
-  newName: quay.io/kata-containers/kata-deploy-ci
-  newTag: kata-containers-latest
+  newTag: 3.21.0
 
 patches:
 - patch: |-

--- a/config/samples/ccruntime/peer-pods/kustomization.yaml
+++ b/config/samples/ccruntime/peer-pods/kustomization.yaml
@@ -9,10 +9,9 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: latest
+  newTag: 6fa876bea238c4ba08af0f9b1a696f28c834e84f
 - name: quay.io/kata-containers/kata-deploy
-  newName: quay.io/kata-containers/kata-deploy-ci
-  newTag: kata-containers-latest
+  newTag: 3.21.0
 
 
 patches:

--- a/config/samples/ccruntime/s390x/kustomization.yaml
+++ b/config/samples/ccruntime/s390x/kustomization.yaml
@@ -8,10 +8,9 @@ resources:
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: latest
+  newTag: 6fa876bea238c4ba08af0f9b1a696f28c834e84f
 - name: quay.io/kata-containers/kata-deploy
-  newName: quay.io/kata-containers/kata-deploy-ci
-  newTag: kata-containers-latest
+  newTag: 3.21.0
 
 patches:
 - patch: |-

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -9,7 +9,7 @@ spec:
       node.kubernetes.io/worker: ""
   config:
     installType: bundle
-    payloadImage: quay.io/confidential-containers/runtime-payload-ci:enclave-cc-HW-cc-kbc-latest
+    payloadImage: quay.io/confidential-containers/runtime-payload:enclave-cc-HW-cc-kbc-v0.11.0
     installDoneLabel:
       confidentialcontainers.org/enclave-cc: "true"
     uninstallDoneLabel:

--- a/config/samples/enclave-cc/hw/kustomization.yaml
+++ b/config/samples/enclave-cc/hw/kustomization.yaml
@@ -8,4 +8,4 @@ nameSuffix: -sgx-mode-hw
 
 images:
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: latest
+  newTag: 6fa876bea238c4ba08af0f9b1a696f28c834e84f

--- a/config/samples/enclave-cc/sim/kustomization.yaml
+++ b/config/samples/enclave-cc/sim/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 nameSuffix: -sgx-mode-sim
 
 images:
-- name: quay.io/confidential-containers/runtime-payload-ci
-  newTag: enclave-cc-SIM-sample-kbc-latest
+- name: quay.io/confidential-containers/runtime-payload
+  newTag: enclave-cc-SIM-sample-kbc-v0.11.0
 - name: quay.io/confidential-containers/reqs-payload
-  newTag: latest
+  newTag: 6fa876bea238c4ba08af0f9b1a696f28c834e84f


### PR DESCRIPTION
PR for step#5 of [checklist for v0.16.0](https://github.com/confidential-containers/confidential-containers/pull/318) 